### PR TITLE
Refactor build command into Project class

### DIFF
--- a/pros/cli/build.py
+++ b/pros/cli/build.py
@@ -1,13 +1,10 @@
 import os
 import os.path
-import sys
-from typing import *
 
 import click
 
 import pros.conductor as c
-from pros.cli.common import pros_root
-from pros.config.cli_config import cli_config
+from pros.cli.common import pros_root, logger, default_options, project_option
 
 
 @pros_root
@@ -16,33 +13,14 @@ def build_cli():
 
 
 @build_cli.command(aliases=['build'])
+@project_option()
 @click.argument('build-args', nargs=-1)
-@click.pass_context
-def make(ctx, build_args):
+@default_options
+def make(project: c.Project, build_args):
     """
     Build current PROS project or cwd
     """
-    import subprocess
-    if cli_config().use_build_compile_commands:
-        return ctx.forward(build_compile_commands)
-    env = os.environ.copy()
-    # Add PROS toolchain to the beginning of PATH to ensure PROS binaries are preferred
-    if os.environ.get('PROS_TOOLCHAIN'):
-        env['PATH'] = os.path.join(os.environ.get('PROS_TOOLCHAIN'), 'bin') + os.pathsep + env['PATH']
-
-    # call make.exe if on Windows
-    if os.name == 'nt' and os.environ.get('PROS_TOOLCHAIN'):
-        make_cmd = os.path.join(os.environ.get('PROS_TOOLCHAIN'), 'bin', 'make.exe')
-    else:
-        make_cmd = 'make'
-    cwd = os.getcwd()
-    if c.Project.find_project(os.getcwd()):
-        cwd = os.path.dirname(c.Project.find_project(os.getcwd()))
-    process = subprocess.Popen(executable=make_cmd, args=[make_cmd, *build_args], cwd=cwd, env=env,
-                               stdout=sys.stdout, stderr=sys.stderr)
-    process.wait()
-    if process.returncode != 0:
-        ctx.exit(process.returncode)
+    return project.compile(build_args)
 
 
 @build_cli.command('make-upload', aliases=['mu'], hidden=True)
@@ -70,112 +48,8 @@ def build_compile_commands(build_args):
     Build a compile_commands.json compatible with cquery
     :return:
     """
-    from libscanbuild.compilation import Compilation, CompilationDatabase
-    from libscanbuild.arguments import create_intercept_parser
-    import itertools
-
-    import argparse
-
-    def libscanbuild_capture(args: argparse.Namespace) -> Tuple[int, Iterable[Compilation]]:
-        from libscanbuild.intercept import setup_environment, run_build, exec_trace_files, parse_exec_trace, \
-            compilations
-        from libear import temporary_directory
-        """ Implementation of compilation database generation.
-        :param args:    the parsed and validated command line arguments
-        :return:        the exit status of build process. """
-
-        with temporary_directory(prefix='intercept-') as tmp_dir:
-            # run the build command
-            environment = setup_environment(args, tmp_dir)
-            if os.environ.get('PROS_TOOLCHAIN'):
-                environment['PATH'] = os.path.join(os.environ.get('PROS_TOOLCHAIN'), 'bin') + os.pathsep + environment[
-                    'PATH']
-            exit_code = run_build(args.build, env=environment)
-            # read the intercepted exec calls
-            calls = (parse_exec_trace(file) for file in exec_trace_files(tmp_dir))
-            current = compilations(calls, args.cc, args.cxx)
-
-            return exit_code, iter(set(current))
-
-    # call make.exe if on Windows
-    if os.name == 'nt' and os.environ.get('PROS_TOOLCHAIN'):
-        make_cmd = os.path.join(os.environ.get('PROS_TOOLCHAIN'), 'bin', 'make.exe')
-    else:
-        make_cmd = 'make'
-    args = create_intercept_parser().parse_args(
-        ['--override-compiler', '--use-cc', 'arm-none-eabi-gcc', '--use-c++', 'arm-none-eabi-g++', make_cmd,
-         *build_args,
-         'CC=intercept-cc', 'CXX=intercept-c++'])
-    exit_code, entries = libscanbuild_capture(args)
-
-    any_entries, entries = itertools.tee(entries, 2)
-    if not any(any_entries):
-        return
-    click.echo('Capturing metadata for PROS Editor...')
-    import subprocess
-    env = os.environ.copy()
-    # Add PROS toolchain to the beginning of PATH to ensure PROS binaries are preferred
-    if os.environ.get('PROS_TOOLCHAIN'):
-        env['PATH'] = os.path.join(os.environ.get('PROS_TOOLCHAIN'), 'bin') + os.pathsep + env['PATH']
-    cc_sysroot = subprocess.run([make_cmd, 'cc-sysroot'], env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    lines = str(cc_sysroot.stdout.decode()).splitlines()
-    lines = [l.strip() for l in lines]
-    cc_sysroot_includes = []
-    copy = False
-    for line in lines:
-        if line == '#include <...> search starts here:':
-            copy = True
-            continue
-        if line == 'End of search list.':
-            copy = False
-            continue
-        if copy:
-            cc_sysroot_includes.append(f'-isystem{line}')
-    cxx_sysroot = subprocess.run([make_cmd, 'cxx-sysroot'], env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    lines = str(cxx_sysroot.stdout.decode()).splitlines()
-    lines = [l.strip() for l in lines]
-    cxx_sysroot_includes = []
-    copy = False
-    for line in lines:
-        if line == '#include <...> search starts here:':
-            copy = True
-            continue
-        if line == 'End of search list.':
-            copy = False
-            continue
-        if copy:
-            cxx_sysroot_includes.append(f'-isystem{line}')
-    new_entries, entries = itertools.tee(entries, 2)
-    new_sources = set([e.source for e in entries])
-    if os.path.isfile(args.cdb):
-        old_entries = itertools.filterfalse(lambda entry: entry.source in new_sources,
-                                            CompilationDatabase.load(args.cdb))
-    else:
-        old_entries = []
-
-    extra_flags = ['-target', 'armv7ar-none-none-eabi']
-
-    if sys.platform == 'win32':
-        extra_flags.extend(["-fno-ms-extensions", "-fno-ms-compatibility", "-fno-delayed-template-parsing"])
-
-    def new_entry_map(entry):
-        if entry.compiler == 'c':
-            entry.flags = extra_flags + cc_sysroot_includes + entry.flags
-        elif entry.compiler == 'c++':
-            entry.flags = extra_flags + cxx_sysroot_includes + entry.flags
-        return entry
-
-    new_entries = map(new_entry_map, new_entries)
-
-    def entry_map(entry: Compilation):
-        json_entry = entry.as_db_entry()
-        json_entry['arguments'][0] = 'clang' if entry.compiler == 'cc' else 'clang++'
-        return json_entry
-
-    entries = itertools.chain(old_entries, new_entries)
-    json_entries = list(map(entry_map, entries))
-    with open(args.cdb, 'w') as handle:
-        import json
-        json.dump(json_entries, handle, sort_keys=True, indent=4)
-
-    return exit_code
+    project_path = c.Project.find_project(os.getcwd())
+    if not project_path:
+        logger(__name__).error('You must be inside a PROS project to invoke this command')
+        return -1
+    return c.Project(project_path).compile(build_args, scan_build=True)

--- a/pros/conductor/project.py
+++ b/pros/conductor/project.py
@@ -178,8 +178,12 @@ class Project(Config):
         else:
             make_cmd = 'make'
         cwd = self.location
+        stdout_pipe = EchoPipe()
+        stderr_pipe = EchoPipe(err=True)
         process = subprocess.Popen(executable=make_cmd, args=[make_cmd, *build_args], cwd=cwd, env=env,
-                                   stdout=EchoPipe(), stderr=EchoPipe())
+                                   stdout=stdout_pipe, stderr=stderr_pipe)
+        stdout_pipe.close()
+        stderr_pipe.close()
         process.wait()
         return process.returncode
 

--- a/pros/conductor/project.py
+++ b/pros/conductor/project.py
@@ -1,8 +1,10 @@
 import glob
 import os.path
+import sys
 from typing import *
 
 from pros.common import *
+from pros.common.ui import EchoPipe
 from pros.config.config import Config, ConfigNotFoundException
 from .templates import LocalTemplate, Template, BaseTemplate
 from .transaction import Transaction
@@ -111,7 +113,7 @@ class Project(Config):
         self.templates[template.name] = template
         self.save()
 
-    def remove_template(self, template: Template, remove_user: bool=False, remove_empty_directories: bool=True):
+    def remove_template(self, template: Template, remove_user: bool = False, remove_empty_directories: bool = True):
         if not self.template_is_installed(template):
             raise ValueError(f'{template.identifier} is not installed on this project.')
         if template.name == 'kernel':
@@ -162,6 +164,146 @@ class Project(Config):
         elif hasattr(self.__dict__, 'output'):
             return self.__dict__['output']
         return 'bin/output.bin'
+
+    def _make(self, build_args: List[str]):
+        import subprocess
+        env = os.environ.copy()
+        # Add PROS toolchain to the beginning of PATH to ensure PROS binaries are preferred
+        if os.environ.get('PROS_TOOLCHAIN'):
+            env['PATH'] = os.path.join(os.environ.get('PROS_TOOLCHAIN'), 'bin') + os.pathsep + env['PATH']
+
+        # call make.exe if on Windows
+        if os.name == 'nt' and os.environ.get('PROS_TOOLCHAIN'):
+            make_cmd = os.path.join(os.environ.get('PROS_TOOLCHAIN'), 'bin', 'make.exe')
+        else:
+            make_cmd = 'make'
+        cwd = self.location
+        process = subprocess.Popen(executable=make_cmd, args=[make_cmd, *build_args], cwd=cwd, env=env,
+                                   stdout=EchoPipe(), stderr=EchoPipe())
+        process.wait()
+        return process.returncode
+
+    def _make_scan_build(self, build_args: List[str]):
+        from libscanbuild.compilation import Compilation, CompilationDatabase
+        from libscanbuild.arguments import create_intercept_parser
+        import itertools
+
+        import argparse
+
+        def libscanbuild_capture(args: argparse.Namespace) -> Tuple[int, Iterable[Compilation]]:
+            from libscanbuild.intercept import setup_environment, run_build, exec_trace_files, parse_exec_trace, \
+                compilations
+            from libear import temporary_directory
+            """ Implementation of compilation database generation.
+            :param args:    the parsed and validated command line arguments
+            :return:        the exit status of build process. """
+
+            with temporary_directory(prefix='intercept-') as tmp_dir:
+                # run the build command
+                environment = setup_environment(args, tmp_dir)
+                if os.environ.get('PROS_TOOLCHAIN'):
+                    environment['PATH'] = os.path.join(os.environ.get('PROS_TOOLCHAIN'), 'bin') + os.pathsep + \
+                                          environment[
+                                              'PATH']
+                pipe = EchoPipe()
+                exit_code = run_build(args.build, env=environment, stdout=pipe, stderr=pipe)
+                pipe.close()
+                # read the intercepted exec calls
+                calls = (parse_exec_trace(file) for file in exec_trace_files(tmp_dir))
+                current = compilations(calls, args.cc, args.cxx)
+
+                return exit_code, iter(set(current))
+
+        # call make.exe if on Windows
+        if os.name == 'nt' and os.environ.get('PROS_TOOLCHAIN'):
+            make_cmd = os.path.join(os.environ.get('PROS_TOOLCHAIN'), 'bin', 'make.exe')
+        else:
+            make_cmd = 'make'
+        args = create_intercept_parser().parse_args(
+            ['--override-compiler', '--use-cc', 'arm-none-eabi-gcc', '--use-c++', 'arm-none-eabi-g++', make_cmd,
+             *build_args,
+             'CC=intercept-cc', 'CXX=intercept-c++'])
+        exit_code, entries = libscanbuild_capture(args)
+
+        any_entries, entries = itertools.tee(entries, 2)
+        if not any(any_entries):
+            return
+        ui.echo('Capturing metadata for PROS Editor...')
+        import subprocess
+        env = os.environ.copy()
+        # Add PROS toolchain to the beginning of PATH to ensure PROS binaries are preferred
+        if os.environ.get('PROS_TOOLCHAIN'):
+            env['PATH'] = os.path.join(os.environ.get('PROS_TOOLCHAIN'), 'bin') + os.pathsep + env['PATH']
+        cc_sysroot = subprocess.run([make_cmd, 'cc-sysroot'], env=env, stdout=subprocess.PIPE,
+                                    stderr=subprocess.DEVNULL)
+        lines = str(cc_sysroot.stdout.decode()).splitlines()
+        lines = [l.strip() for l in lines]
+        cc_sysroot_includes = []
+        copy = False
+        for line in lines:
+            if line == '#include <...> search starts here:':
+                copy = True
+                continue
+            if line == 'End of search list.':
+                copy = False
+                continue
+            if copy:
+                cc_sysroot_includes.append(f'-isystem{line}')
+        cxx_sysroot = subprocess.run([make_cmd, 'cxx-sysroot'], env=env, stdout=subprocess.PIPE,
+                                     stderr=subprocess.DEVNULL)
+        lines = str(cxx_sysroot.stdout.decode()).splitlines()
+        lines = [l.strip() for l in lines]
+        cxx_sysroot_includes = []
+        copy = False
+        for line in lines:
+            if line == '#include <...> search starts here:':
+                copy = True
+                continue
+            if line == 'End of search list.':
+                copy = False
+                continue
+            if copy:
+                cxx_sysroot_includes.append(f'-isystem{line}')
+        new_entries, entries = itertools.tee(entries, 2)
+        new_sources = set([e.source for e in entries])
+        if os.path.isfile(args.cdb):
+            old_entries = itertools.filterfalse(lambda entry: entry.source in new_sources,
+                                                CompilationDatabase.load(args.cdb))
+        else:
+            old_entries = []
+
+        extra_flags = ['-target', 'armv7ar-none-none-eabi']
+
+        if sys.platform == 'win32':
+            extra_flags.extend(["-fno-ms-extensions", "-fno-ms-compatibility", "-fno-delayed-template-parsing"])
+
+        def new_entry_map(entry):
+            if entry.compiler == 'c':
+                entry.flags = extra_flags + cc_sysroot_includes + entry.flags
+            elif entry.compiler == 'c++':
+                entry.flags = extra_flags + cxx_sysroot_includes + entry.flags
+            return entry
+
+        new_entries = map(new_entry_map, new_entries)
+
+        def entry_map(entry: Compilation):
+            json_entry = entry.as_db_entry()
+            json_entry['arguments'][0] = 'clang' if entry.compiler == 'cc' else 'clang++'
+            return json_entry
+
+        entries = itertools.chain(old_entries, new_entries)
+        json_entries = list(map(entry_map, entries))
+        with open(args.cdb, 'w') as handle:
+            import json
+            json.dump(json_entries, handle, sort_keys=True, indent=4)
+
+        return exit_code
+
+    def compile(self, build_args: List[str], scan_build: Optional[bool] = None):
+        if scan_build is None:
+            from pros.config.cli_config import cli_config
+            scan_build = cli_config().use_build_compile_commands
+        return self._make_scan_build(build_args) if scan_build else self._make(build_args)
 
     @staticmethod
     def find_project(path: str, recurse_times: int = 10):


### PR DESCRIPTION
Summary:

Refactored build command into Project class to make invoking build from different places simpler

Test Plan:
- [x] Run `prosv5 make`
- [x] Run `prosv5 make --machine-output`
- [X] Run `prosv5 build-compile-commands`
- [X] Run `prosv5 build-compile-commands --machine-output`