### PR TITLE
Migrate --compile-after to use new Project.compile function

### DIFF
--- a/pros/cli/conductor.py
+++ b/pros/cli/conductor.py
@@ -210,7 +210,7 @@ def new_project(ctx: click.Context, path: str, target: str, version: str,
 
         if compile_after or build_cache:
             with ui.Notification():
-                project.compile([], scan_build=build_cache)
+                ctx.exit(project.compile([], scan_build=build_cache))
 
     except Exception as e:
         pros.common.logger(__name__).exception(e)

--- a/pros/cli/conductor.py
+++ b/pros/cli/conductor.py
@@ -197,7 +197,7 @@ def new_project(ctx: click.Context, path: str, target: str, version: str,
         version = '>0'
     if not force_system and c.Project.find_project(path) is not None:
         pros.common.logger(__name__).error('A project already exists in this location! Delete it first')
-        return -1
+        ctx.exit(-1)
     try:
         _conductor = c.Conductor()
         if target is None:
@@ -209,22 +209,12 @@ def new_project(ctx: click.Context, path: str, target: str, version: str,
         ctx.invoke(info_project, project=project)
 
         if compile_after or build_cache:
-            if not build_cache:
-                from .build import make
-                oldcwd = os.getcwd()
-                os.chdir(path)
-                ctx.invoke(make)
-                os.chdir(oldcwd)
-            else:
-                from .build import build_compile_commands
-                oldcwd = os.getcwd()
-                os.chdir(path)
-                ctx.invoke(build_compile_commands)
-                os.chdir(oldcwd)
+            with ui.Notification():
+                project.compile([], scan_build=build_cache)
 
     except Exception as e:
         pros.common.logger(__name__).exception(e)
-        return -1
+        ctx.exit(-1)
 
 
 @conductor.command('query-templates',

--- a/pros/conductor/project.py
+++ b/pros/conductor/project.py
@@ -231,7 +231,7 @@ class Project(Config):
 
         any_entries, entries = itertools.tee(entries, 2)
         if not any(any_entries):
-            return
+            return exit_code
         ui.echo('Capturing metadata for PROS Editor...')
         import subprocess
         env = os.environ.copy()

--- a/pros/conductor/project.py
+++ b/pros/conductor/project.py
@@ -210,7 +210,7 @@ class Project(Config):
                                           environment[
                                               'PATH']
                 pipe = EchoPipe()
-                exit_code = run_build(args.build, env=environment, stdout=pipe, stderr=pipe)
+                exit_code = run_build(args.build, env=environment, stdout=pipe, stderr=pipe, cwd=self.directory)
                 pipe.close()
                 # read the intercepted exec calls
                 calls = (parse_exec_trace(file) for file in exec_trace_files(tmp_dir))
@@ -239,7 +239,7 @@ class Project(Config):
         if os.environ.get('PROS_TOOLCHAIN'):
             env['PATH'] = os.path.join(os.environ.get('PROS_TOOLCHAIN'), 'bin') + os.pathsep + env['PATH']
         cc_sysroot = subprocess.run([make_cmd, 'cc-sysroot'], env=env, stdout=subprocess.PIPE,
-                                    stderr=subprocess.DEVNULL)
+                                    stderr=subprocess.DEVNULL, cwd=self.directory)
         lines = str(cc_sysroot.stdout.decode()).splitlines()
         lines = [l.strip() for l in lines]
         cc_sysroot_includes = []
@@ -254,7 +254,7 @@ class Project(Config):
             if copy:
                 cc_sysroot_includes.append(f'-isystem{line}')
         cxx_sysroot = subprocess.run([make_cmd, 'cxx-sysroot'], env=env, stdout=subprocess.PIPE,
-                                     stderr=subprocess.DEVNULL)
+                                     stderr=subprocess.DEVNULL, cwd=self.directory)
         lines = str(cxx_sysroot.stdout.decode()).splitlines()
         lines = [l.strip() for l in lines]
         cxx_sysroot_includes = []
@@ -270,9 +270,10 @@ class Project(Config):
                 cxx_sysroot_includes.append(f'-isystem{line}')
         new_entries, entries = itertools.tee(entries, 2)
         new_sources = set([e.source for e in entries])
-        if os.path.isfile(args.cdb):
+        cdb_file = os.path.join(self.directory, 'compile_commands.json')
+        if os.path.isfile(cdb_file):
             old_entries = itertools.filterfalse(lambda entry: entry.source in new_sources,
-                                                CompilationDatabase.load(args.cdb))
+                                                CompilationDatabase.load(cdb_file))
         else:
             old_entries = []
 
@@ -297,7 +298,7 @@ class Project(Config):
 
         entries = itertools.chain(old_entries, new_entries)
         json_entries = list(map(entry_map, entries))
-        with open(args.cdb, 'w') as handle:
+        with open(cdb_file, 'w') as handle:
             import json
             json.dump(json_entries, handle, sort_keys=True, indent=4)
 


### PR DESCRIPTION
## Summary 

- Also fix bug where program return value wasn't being returned as
  expected when creating a new project

## Test Plan
- [X] Run `prosv5 c n a`
- [X] Run `prosv5 c n a` where the project already exists, exit code is -1
- [X] Run `prosv5 c n a --compile-after`, project is compiled successfully'
- [X] Run command inside Atom, build-compile-cache works as does machine output.