### PR TITLE
🚸 Don't silently exit on no located port

### DIFF
--- a/pros/cli/upload.py
+++ b/pros/cli/upload.py
@@ -75,7 +75,7 @@ def upload(path: str, port: str, **kwargs):
         logger(__name__).debug(f"Invalid target provided: {kwargs['target']}")
         logger(__name__).debug('Target should be one of ("v5" or "cortex").')
     if not port:
-        return -1
+        raise click.UsageError('No port provided or located. Make sure to specify --target if needed.')
 
     if kwargs['target'] == 'v5':
         if kwargs['name'] is None:

--- a/pros/cli/upload.py
+++ b/pros/cli/upload.py
@@ -75,7 +75,7 @@ def upload(path: str, port: str, **kwargs):
         logger(__name__).debug(f"Invalid target provided: {kwargs['target']}")
         logger(__name__).debug('Target should be one of ("v5" or "cortex").')
     if not port:
-        raise click.UsageError('No port provided or located. Make sure to specify --target if needed.')
+        raise dont_send(click.UsageError('No port provided or located. Make sure to specify --target if needed.'))
 
     if kwargs['target'] == 'v5':
         if kwargs['name'] is None:


### PR DESCRIPTION
When uploading by specifying a file instead of project if no target nor port are provided `prosv5 u` will exit silently which is a confusing behaviour.