### PR TITLE
Implement V5 screen capture

### DIFF
--- a/pros/cli/v5_utils.py
+++ b/pros/cli/v5_utils.py
@@ -192,3 +192,53 @@ def stop(port: str):
     ser = DirectPort(port)
     device = V5Device(ser)
     device.execute_program_file('', run=False)
+
+
+@v5.command(short_help='Take a screen capture of the display')
+@click.argument('file_name', required=False, default=None)
+@click.argument('port', required=False, default=None)
+@click.option('--force', is_flag=True, type=bool, default=False)
+@default_options
+def capture(file_name: str, port: str, force: bool = False):
+    """
+    Take a screen capture of the display
+    """
+    from pros.serial.devices.vex import V5Device
+    from pros.serial.ports import DirectPort
+    import png
+    import os
+
+    port = resolve_v5_port(port, 'system')
+    if not port:
+        return -1
+    ser = DirectPort(port)
+    device = V5Device(ser)
+    i_data, width, height = device.get_screen_capture_data()
+
+    if i_data is None:
+        print('Failed to capture screen from connected brain.')
+        return -1
+
+    # Sanity checking and default values for filenames
+    if file_name is None:
+        import time
+        time_s = time.strftime('%Y-%m-%d-%H%M%S')
+        file_name = f'{time_s}_{width}x{height}_pros_capture.png'
+    if file_name == '-':
+        # Send the data to stdout to allow for piping
+        print(png_data, end='')
+        return
+
+    if not file_name.endswith('.png'):
+        file_name += '.png'
+
+    if not force and os.path.exists(file_name):
+        print(f'{file_name} already exists. Refusing to overwrite!')
+        print('Re-run this command with the --force argument to overwrite existing files.')
+        return -1
+
+    with open(file_name, 'wb') as file_:
+        w = png.Writer(width, height)
+        w.write(file_, i_data)
+
+    print(f'Saved screen capture to {file_name}')

--- a/pros/cli/v5_utils.py
+++ b/pros/cli/v5_utils.py
@@ -213,7 +213,7 @@ def capture(file_name: str, port: str, force: bool = False):
         return -1
     ser = DirectPort(port)
     device = V5Device(ser)
-    i_data, width, height = device.get_screen_capture_data()
+    i_data, width, height = device.capture_screen()
 
     if i_data is None:
         print('Failed to capture screen from connected brain.')
@@ -226,7 +226,7 @@ def capture(file_name: str, port: str, force: bool = False):
         file_name = f'{time_s}_{width}x{height}_pros_capture.png'
     if file_name == '-':
         # Send the data to stdout to allow for piping
-        print(png_data, end='')
+        print(i_data, end='')
         return
 
     if not file_name.endswith('.png'):

--- a/pros/serial/devices/vex/v5_device.py
+++ b/pros/serial/devices/vex/v5_device.py
@@ -8,9 +8,8 @@ from io import BytesIO, StringIO
 from typing import *
 
 from pros.common import *
-from pros.serial import bytes_to_str
-from pros.serial import decode_bytes_to_str
-from pros.serial.ports import list_all_comports, BasePort
+from pros.serial import bytes_to_str, decode_bytes_to_str
+from pros.serial.ports import BasePort, list_all_comports
 from .comm_error import VEXCommError
 from .crc import CRC
 from .message import Message
@@ -149,16 +148,24 @@ class V5Device(VEXDevice, SystemDevice):
         else:
             raise ValueError(f'Unknown quirk option: {quirk}')
 
-    def read_file(self, file: typing.IO[bytes], remote_file: str, vid: int_str = 'user', target: int_str = 'flash'):
+    def read_file(self, file: typing.IO[bytes], remote_file: str, vid: int_str = 'user', target: int_str = 'flash',
+                  addr: Optional[int] = None, file_len: Optional[int] = None):
         if isinstance(vid, str):
             vid = self.vid_map[vid.lower()]
-        metadata = self.get_file_metadata_by_name(remote_file, vid=vid)
+        if addr is None:
+            metadata = self.get_file_metadata_by_name(remote_file, vid=vid)
+            addr = metadata['addr']
         ft_meta = self.ft_initialize(remote_file, function='download', vid=vid, target=target)
-        for i in range(0, ft_meta['file_size'], ft_meta['max_packet_size']):
-            packet_size = ft_meta['max_packet_size']
-            if i + ft_meta['max_packet_size'] > ft_meta['file_size']:
-                packet_size = ft_meta['file_size'] - i
-            file.write(self.ft_read(metadata['addr'] + i, packet_size))
+        if file_len is None:
+            file_len = ft_meta['file_size']
+        with ui.progressbar(length=file_len, label='Downloading {}'.format(remote_file)) as progress:
+            for i in range(0, file_len, ft_meta['max_packet_size']):
+                packet_size = ft_meta['max_packet_size']
+                if i + ft_meta['max_packet_size'] > file_len:
+                    packet_size = ft_meta['file_size'] - i
+                file.write(self.ft_read(addr + i, packet_size))
+                progress.update(packet_size)
+                logger(__name__).debug('Completed {} of {} bytes'.format(i + packet_size, file_len))
         self.ft_complete()
 
     def write_file(self, file: typing.BinaryIO, remote_file: str, file_len: int = -1,
@@ -189,6 +196,26 @@ class V5Device(VEXDevice, SystemDevice):
                 logger(__name__).debug('Completed {} of {} bytes'.format(i + packet_size, file_len))
         logger(__name__).debug('Data transfer complete, sending ft complete')
         self.ft_complete(options=run_after)
+
+    def capture_screen(self) -> Tuple[List[int], int, int]:
+        self.sc_init()
+        width, height = 512, 272
+        file_size = width * height * 4  # ARGB
+
+        rx_io = BytesIO()
+        self.read_file(rx_io, '', vid='system', target='screen', addr=0, file_len=file_size)
+        rx = rx_io.getvalue()
+
+        i, data = 0, [[] for _ in range(height)]
+        for y in range(height):
+            for x in range(width - 1):
+                if x < 480:
+                    px = rx[y * width + x]
+                    data[y].append((px & 0xff0000) >> 16)
+                    data[y].append((px & 0x00ff00) >> 8)
+                    data[y].append(px & 0x0000ff)
+
+        return data, 480, height
 
     @retries
     def query_system_version(self) -> bytearray:
@@ -404,39 +431,14 @@ class V5Device(VEXDevice, SystemDevice):
         }
 
     @retries
-    def do_screen_capture(self) -> None:
+    def sc_init(self) -> None:
+        """
+        Send command to initialize screen capture
+        """
         # This will only copy data in memory, not send!
         logger(__name__).debug('Sending ext 0x28 command')
         rx = self._txrx_ext_struct(0x28, [], '')
         logger(__name__).debug('Completed ext 0x28 command')
-
-    def get_screen_capture_data(self, crop_w: int = 480) -> List[List[int]]:
-        self.do_screen_capture()
-        width, height = 512, 272
-        file_size = width * height * 4  # ARGB
-
-        rx = []
-        ft_meta = self.ft_initialize('', function='download', vid='system', target='screen')
-        for i in range(0, file_size, ft_meta['max_packet_size']):
-            packet_size = ft_meta['max_packet_size']
-            if i + ft_meta['max_packet_size'] > file_size:
-                packet_size = file_size - i
-
-            tx_payload = struct.pack("<IH", i, packet_size)
-            rx_fmt = "<I{}I".format(packet_size // 4)
-            rx += [*self._txrx_ext_struct(0x14, tx_payload, rx_fmt, check_ack=False, check_length=False)[1:]]
-        self.ft_complete()
-
-        i, data = 0, [[] for _ in range(height)]
-        for y in range(height):
-            for x in range(width - 1):
-                if x < crop_w:
-                    px = rx[y * width + x]
-                    data[y].append((px & 0xff0000) >> 16)
-                    data[y].append((px & 0x00ff00) >> 8)
-                    data[y].append(px & 0x0000ff)
-
-        return data, crop_w, height
 
     def _txrx_ext_struct(self, command: int, tx_data: Union[Iterable, bytes, bytearray],
                          unpack_fmt: str, check_length: bool = True, check_ack: bool = True,

--- a/pros/serial/devices/vex/v5_device.py
+++ b/pros/serial/devices/vex/v5_device.py
@@ -206,7 +206,7 @@ class V5Device(VEXDevice, SystemDevice):
         self.read_file(rx_io, '', vid='system', target='screen', addr=0, file_len=file_size)
         rx = rx_io.getvalue()
 
-        i, data = 0, [[] for _ in range(height)]
+        data = [[] for _ in range(height)]
         for y in range(height):
             for x in range(width - 1):
                 if x < 480:
@@ -437,7 +437,7 @@ class V5Device(VEXDevice, SystemDevice):
         """
         # This will only copy data in memory, not send!
         logger(__name__).debug('Sending ext 0x28 command')
-        rx = self._txrx_ext_struct(0x28, [], '')
+        self._txrx_ext_struct(0x28, [], '')
         logger(__name__).debug('Completed ext 0x28 command')
 
     def _txrx_ext_struct(self, command: int, tx_data: Union[Iterable, bytes, bytearray],

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ cobs
 scan-build
 rfc6266-parser
 raven
+pypng


### PR DESCRIPTION
## Changes:
- A new command `prosv5 v5 capture [--force] [file name] [port]` was added that will take a screenshot (refusing to overwrite existing image unless `--force` is used)
- A new target `screen` was added that maps to `2` as per spec
- `do_screen_capture` was added that copies the screen data to an internal memory location on the brain
- `get_screen_capture_data` was added that calls the above function then reads the data. `ft_read` was not used as the formatting of the output caused incorrect values so instead ln427 manually performs the repeated memory reads. This data is then cropped to the required output width (default 480, as per spec) to accommodate to padding.
- `pypng` was added as a hard dependency to support writing of PNG files.

## Testing plan

- [x] Run `prosv5 v5 capture` and observe an screenshot being saved in the same directory with a timestamped filename.
- [x] Run `prosv5 v5 capture myFile` and observe a screenshot saved in the same directory named `myFile.png`
- [x] Run `prosv5 v5 capture myFile2.png` and observe a screenshot saved in the same directory named `myFile2.png`
- [x] Run `prosv5 v5 capture myFile2.png` a second time and observe the command refusing to overwrite an existing file.
- [x] Run `prosv5 v5 capture myFile2.png --force` and observe the existing file being overwritten regardless.

_Note: Make sure you have a decent USB cable, as I found that using the VEX-provided cable some of the packets failed to be received whereas switching to a known-good cable fixed that._