### PR TITLE
✨ 📶 Add wireless V5 uploading 

### DIFF
--- a/pros/serial/devices/vex/v5_device.py
+++ b/pros/serial/devices/vex/v5_device.py
@@ -36,7 +36,6 @@ def find_v5_ports(p_type: str):
     # Doesn't work on macOS or Jonathan's Dell, so we have a fallback (below)
     user_ports = [p for p in ports if filter_v5_ports(p, ['2'], ['User'])]
     system_ports = [p for p in ports if filter_v5_ports(p, ['0'], ['System', 'Communications'])]
-    joystick_ports = []  # joystick comms are very slow/unusable
     joystick_ports = [p for p in ports if filter_v5_ports(p, ['1'], ['Controller'])]
 
     # TODO: test this code path (hard)
@@ -74,6 +73,11 @@ def find_v5_ports(p_type: str):
 
 
 def with_download_channel(f):
+    """
+    Function decorator for use inside V5Device class. Needs to be outside the class because @staticmethod prevents
+    us from making a function decorator
+    """
+
     def wrapped(device, *args, **kwargs):
         with V5Device.DownloadChannel(device):
             f(device, *args, **kwargs)
@@ -102,8 +106,7 @@ class V5Device(VEXDevice, SystemDevice):
             pass
 
         class ControllerFlags(IntFlag):
-            CONNECTED = 0x0200
-            PIT_CHANNEL = 0x0004
+            CONNECTED = 0x02
 
         flag_map = {Product.BRAIN: BrainFlags, Product.CONTROLLER: ControllerFlags}
 
@@ -146,9 +149,6 @@ class V5Device(VEXDevice, SystemDevice):
                 self.device.default_timeout = 2.
                 if V5Device.SystemVersion.ControllerFlags.CONNECTED not in version.product_flags:
                     raise VEXCommError('V5 Controller doesn\'t appear to be connected to a V5 Brain', version)
-                if V5Device.SystemVersion.ControllerFlags.PIT_CHANNEL not in version.product_flags:
-                    logger(__name__).debug('Already in download channel!')
-                    return self  # already in download channel
                 ui.echo('Transferring V5 to download channel')
                 self.device.ft_transfer_channel('download')
                 logger(__name__).debug('Sleeping for a while to let V5 start channel transfer')
@@ -159,12 +159,8 @@ class V5Device(VEXDevice, SystemDevice):
                 while V5Device.SystemVersion.ControllerFlags.CONNECTED not in version.product_flags and \
                         time.time() - start_time < self.timeout:
                     version = self.device.query_system_version()
-                    if V5Device.SystemVersion.ControllerFlags.CONNECTED in version.product_flags and \
-                            V5Device.SystemVersion.ControllerFlags.PIT_CHANNEL not in version.product_flags:
-                        break
                     time.sleep(0.25)
-                if V5Device.SystemVersion.ControllerFlags.PIT_CHANNEL in version.product_flags or \
-                        V5Device.SystemVersion.ControllerFlags.CONNECTED not in version.product_flags:
+                if V5Device.SystemVersion.ControllerFlags.CONNECTED not in version.product_flags:
                     raise VEXCommError('Could not transfer V5 Controller to download channel', version)
                 logger(__name__).info('V5 should been transferred to higher bandwidth download channel')
                 return self
@@ -173,9 +169,9 @@ class V5Device(VEXDevice, SystemDevice):
 
         def __exit__(self, *exc):
             version = self.device.query_system_version()
-            if V5Device.SystemVersion.ControllerFlags.PIT_CHANNEL not in version.product_flags:
-                ui.echo('V5 has been transferred back to pit channel')
+            if version.product == V5Device.SystemVersion.Product.CONTROLLER:
                 self.device.ft_transfer_channel('pit')
+                ui.echo('V5 has been transferred back to pit channel')
 
     @property
     def status(self):
@@ -289,7 +285,7 @@ class V5Device(VEXDevice, SystemDevice):
         self.ft_complete(options=run_after)
 
     @with_download_channel
-    def capture_screen(self) -> Tuple[List[int], int, int]:
+    def capture_screen(self) -> Tuple[List[List[int]], int, int]:
         self.sc_init()
         width, height = 512, 272
         file_size = width * height * 4  # ARGB
@@ -312,7 +308,7 @@ class V5Device(VEXDevice, SystemDevice):
     @retries
     def query_system_version(self) -> SystemVersion:
         logger(__name__).debug('Sending simple 0xA408 command')
-        ret = self._txrx_simple_struct(0xA4, '>6BH')
+        ret = self._txrx_simple_struct(0xA4, '>8B')
         logger(__name__).debug('Completed simple 0xA408 command')
         return V5Device.SystemVersion(ret)
 

--- a/pros/serial/devices/vex/v5_device.py
+++ b/pros/serial/devices/vex/v5_device.py
@@ -1,9 +1,10 @@
 import re
 import struct
+import time
 import typing
 from configparser import ConfigParser
 from datetime import datetime, timedelta
-from enum import IntEnum
+from enum import IntEnum, IntFlag
 from io import BytesIO, StringIO
 from typing import *
 
@@ -36,7 +37,7 @@ def find_v5_ports(p_type: str):
     user_ports = [p for p in ports if filter_v5_ports(p, ['2'], ['User'])]
     system_ports = [p for p in ports if filter_v5_ports(p, ['0'], ['System', 'Communications'])]
     joystick_ports = []  # joystick comms are very slow/unusable
-    # joystick_ports = [p for p in ports if filter_v5_ports(p, ['1'], ['Controller'])]
+    joystick_ports = [p for p in ports if filter_v5_ports(p, ['1'], ['Controller'])]
 
     # TODO: test this code path (hard)
     if len(user_ports) != len(system_ports):
@@ -72,8 +73,17 @@ def find_v5_ports(p_type: str):
     return []
 
 
+def with_download_channel(f):
+    def wrapped(device, *args, **kwargs):
+        with V5Device.DownloadChannel(device):
+            f(device, *args, **kwargs)
+
+    return wrapped
+
+
 class V5Device(VEXDevice, SystemDevice):
     vid_map = {'user': 1, 'system': 15}  # type: Dict[str, int]
+    channel_map = {'pit': 0, 'download': 1}  # type: Dict[str, int]
 
     class FTCompleteOptions(IntEnum):
         DONT_RUN = 0
@@ -83,9 +93,89 @@ class V5Device(VEXDevice, SystemDevice):
     VEX_CRC16 = CRC(16, 0x1021)  # CRC-16-CCIT
     VEX_CRC32 = CRC(32, 0x04C11DB7)  # CRC-32 (the one used everywhere but has no name)
 
+    class SystemVersion(object):
+        class Product(IntEnum):
+            CONTROLLER = 0x11
+            BRAIN = 0x10
+
+        class BrainFlags(IntFlag):
+            pass
+
+        class ControllerFlags(IntFlag):
+            CONNECTED = 0x0200
+            PIT_CHANNEL = 0x0004
+
+        flag_map = {Product.BRAIN: BrainFlags, Product.CONTROLLER: ControllerFlags}
+
+        def __init__(self, data: tuple):
+            from semantic_version import Version
+            self.system_version = Version('{}.{}.{}-{}.{}'.format(*data[0:5]))
+            self.product = V5Device.SystemVersion.Product(data[5])
+            self.product_flags = self.flag_map[self.product](data[6])
+
+        def __str__(self):
+            return f'System Version: {self.system_version}\n' \
+                f'       Product: {self.product.name}\n' \
+                f' Product Flags: {self.product_flags.value:x}'
+
+    class SystemStatus(object):
+        def __init__(self, data: tuple):
+            from semantic_version import Version
+            self.system_version = Version('{}.{}.{}-{}'.format(*data[0:4]))
+            self.cpu0_version = Version('{}.{}.{}-{}'.format(*data[4:8]))
+            self.cpu1_version = Version('{}.{}.{}-{}'.format(*data[8:12]))
+            self.touch_version = data[12]
+            self.system_id = data[13]
+
+        def __getitem__(self, item):
+            return self.__dict__[item]
+
     def __init__(self, port: BasePort):
         self._status = None
         super().__init__(port)
+
+    class DownloadChannel(object):
+        def __init__(self, device: 'V5Device', timeout: float = 5.):
+            self.device = device
+            self.timeout = timeout
+            self.did_switch = False
+
+        def __enter__(self):
+            version = self.device.query_system_version()
+            if version.product == V5Device.SystemVersion.Product.CONTROLLER:
+                self.device.default_timeout = 2.
+                if V5Device.SystemVersion.ControllerFlags.CONNECTED not in version.product_flags:
+                    raise VEXCommError('V5 Controller doesn\'t appear to be connected to a V5 Brain', version)
+                if V5Device.SystemVersion.ControllerFlags.PIT_CHANNEL not in version.product_flags:
+                    logger(__name__).debug('Already in download channel!')
+                    return self  # already in download channel
+                ui.echo('Transferring V5 to download channel')
+                self.device.ft_transfer_channel('download')
+                logger(__name__).debug('Sleeping for a while to let V5 start channel transfer')
+                time.sleep(.25)  # wait at least 250ms before starting to poll controller if it's connected yet
+                version = self.device.query_system_version()
+                start_time = time.time()
+                # ask controller every 25 ms if it's connected until it is
+                while V5Device.SystemVersion.ControllerFlags.CONNECTED not in version.product_flags and \
+                        time.time() - start_time < self.timeout:
+                    version = self.device.query_system_version()
+                    if V5Device.SystemVersion.ControllerFlags.CONNECTED in version.product_flags and \
+                            V5Device.SystemVersion.ControllerFlags.PIT_CHANNEL not in version.product_flags:
+                        break
+                    time.sleep(0.25)
+                if V5Device.SystemVersion.ControllerFlags.PIT_CHANNEL in version.product_flags or \
+                        V5Device.SystemVersion.ControllerFlags.CONNECTED not in version.product_flags:
+                    raise VEXCommError('Could not transfer V5 Controller to download channel', version)
+                logger(__name__).info('V5 should been transferred to higher bandwidth download channel')
+                return self
+            else:
+                return self
+
+        def __exit__(self, *exc):
+            version = self.device.query_system_version()
+            if V5Device.SystemVersion.ControllerFlags.PIT_CHANNEL not in version.product_flags:
+                ui.echo('V5 has been transferred back to pit channel')
+                self.device.ft_transfer_channel('pit')
 
     @property
     def status(self):
@@ -112,6 +202,7 @@ class V5Device(VEXDevice, SystemDevice):
             logger(__name__).info(f'Created ini: {ini_str.getvalue()}')
             return ini_str.getvalue()
 
+    @with_download_channel
     def write_program(self, file: typing.BinaryIO, remote_name: str = None, ini: ConfigParser = None, slot: int = 0,
                       file_len: int = -1, run_after: FTCompleteOptions = FTCompleteOptions.DONT_RUN,
                       target: str = 'flash', quirk: int = 0, **kwargs):
@@ -197,6 +288,7 @@ class V5Device(VEXDevice, SystemDevice):
         logger(__name__).debug('Data transfer complete, sending ft complete')
         self.ft_complete(options=run_after)
 
+    @with_download_channel
     def capture_screen(self) -> Tuple[List[int], int, int]:
         self.sc_init()
         width, height = 512, 272
@@ -218,11 +310,21 @@ class V5Device(VEXDevice, SystemDevice):
         return data, 480, height
 
     @retries
-    def query_system_version(self) -> bytearray:
-        logger(__name__).debug('Sending simple 0xA4 command')
-        ret = self._txrx_simple_packet(0xA4, 0x08)
-        logger(__name__).debug('Completed simple 0xA4 command')
-        return ret
+    def query_system_version(self) -> SystemVersion:
+        logger(__name__).debug('Sending simple 0xA408 command')
+        ret = self._txrx_simple_struct(0xA4, '>6BH')
+        logger(__name__).debug('Completed simple 0xA408 command')
+        return V5Device.SystemVersion(ret)
+
+    @retries
+    def ft_transfer_channel(self, channel: int_str):
+        logger(__name__).debug(f'Transferring to {channel} channel')
+        logger(__name__).debug('Sending ext 0x10 command')
+        if isinstance(channel, str):
+            channel = self.channel_map[channel]
+        assert isinstance(channel, int) and 0 <= channel <= 1
+        self._txrx_ext_packet(0x10, struct.pack('<2B', 1, channel), rx_length=0)
+        logger(__name__).debug('Completed ext 0x10 command')
 
     @retries
     def ft_initialize(self, file_name: str, **kwargs) -> Dict[str, Any]:
@@ -417,18 +519,11 @@ class V5Device(VEXDevice, SystemDevice):
         raise NotImplementedError()
 
     @retries
-    def get_system_status(self) -> Dict[str, Any]:
+    def get_system_status(self) -> SystemStatus:
         logger(__name__).debug('Sending ext 0x22 command')
         rx = self._txrx_ext_struct(0x22, [], "<x12B3xBI12x")
         logger(__name__).debug('Completed ext 0x22 command')
-        from semantic_version import Version
-        return {
-            'system_version': Version('{}.{}.{}-{}'.format(*rx[0:4])),
-            'cpu0_version': Version('{}.{}.{}-{}'.format(*rx[4:8])),
-            'cpu1_version': Version('{}.{}.{}-{}'.format(*rx[8:12])),
-            'touch_version': rx[12],
-            'system_id': rx[13]
-        }
+        return V5Device.SystemStatus(rx)
 
     @retries
     def sc_init(self) -> None:
@@ -442,7 +537,7 @@ class V5Device(VEXDevice, SystemDevice):
 
     def _txrx_ext_struct(self, command: int, tx_data: Union[Iterable, bytes, bytearray],
                          unpack_fmt: str, check_length: bool = True, check_ack: bool = True,
-                         timeout: float = 0.1) -> Tuple:
+                         timeout: Optional[float] = None) -> Tuple:
         """
         Transmits and receives an extended command to the V5, automatically unpacking the values according to unpack_fmt
         which gets passed into struct.unpack. The size of the payload is determined from the fmt string
@@ -506,7 +601,7 @@ class V5Device(VEXDevice, SystemDevice):
 
     def _txrx_ext_packet(self, command: int, tx_data: Union[Iterable, bytes, bytearray],
                          rx_length: int, check_length: bool = True,
-                         check_ack: bool = True, timeout: float = 0.1) -> Message:
+                         check_ack: bool = True, timeout: Optional[float] = None) -> Message:
         """
         Transmits and receives an extended command to the V5.
         :param command: Extended command code

--- a/pros/serial/devices/vex/v5_device.py
+++ b/pros/serial/devices/vex/v5_device.py
@@ -38,7 +38,7 @@ def find_v5_ports(p_type: str):
     system_ports = [p for p in ports if filter_v5_ports(p, ['0'], ['System', 'Communications'])]
     joystick_ports = [p for p in ports if filter_v5_ports(p, ['1'], ['Controller'])]
 
-    # TODO: test this code path (hard)
+    # Testing this code path is hard!
     if len(user_ports) != len(system_ports):
         if len(user_ports) > len(system_ports):
             user_ports = [p for p in user_ports if p not in system_ports]
@@ -49,7 +49,7 @@ def find_v5_ports(p_type: str):
         if p_type.lower() == 'user':
             return user_ports
         elif p_type.lower() == 'system':
-            return system_ports
+            return [*system_ports, *joystick_ports]
         else:
             raise ValueError(f'Invalid port type specified: {p_type}')
 
@@ -64,10 +64,10 @@ def find_v5_ports(p_type: str):
         if p_type.lower() == 'user':
             return [ports[1]]
         elif p_type.lower() == 'system':
-            return [ports[0]]
+            return [ports[0], *joystick_ports]
         else:
             raise ValueError(f'Invalid port type specified: {p_type}')
-    if len(joystick_ports) > 0:
+    if len(joystick_ports) > 0 and p_type.lower() == 'system':
         return joystick_ports
     return []
 

--- a/pros/serial/devices/vex/v5_device.py
+++ b/pros/serial/devices/vex/v5_device.py
@@ -53,7 +53,7 @@ def find_v5_ports(p_type: str):
         if p_type.lower() == 'user':
             return user_ports
         elif p_type.lower() == 'system':
-            return [*system_ports, *joystick_ports]
+            return system_ports + joystick_ports
         else:
             raise ValueError(f'Invalid port type specified: {p_type}')
 

--- a/pros/serial/devices/vex/vex_device.py
+++ b/pros/serial/devices/vex/vex_device.py
@@ -4,7 +4,7 @@ from typing import *
 
 from pros.common import *
 from pros.serial import bytes_to_str
-
+from pros.serial.ports import BasePort
 from . import comm_error
 from .message import Message
 from ..generic_device import GenericDevice
@@ -18,6 +18,10 @@ class VEXDevice(GenericDevice):
     ACK_BYTE = 0x76
     NACK_BYTE = 0xFF
 
+    def __init__(self, port: BasePort, timeout=0.1):
+        super().__init__(port)
+        self.default_timeout = timeout
+
     @retries
     def query_system(self) -> bytearray:
         """
@@ -27,11 +31,11 @@ class VEXDevice(GenericDevice):
         logger(__name__).debug('Sending simple 0x21 command')
         return self._txrx_simple_packet(0x21, 0x0A)
 
-    def _txrx_simple_struct(self, command: int, unpack_fmt: str, timeout: float = 0.1) -> Tuple:
+    def _txrx_simple_struct(self, command: int, unpack_fmt: str, timeout: Optional[float] = None) -> Tuple:
         rx = self._txrx_simple_packet(command, struct.calcsize(unpack_fmt), timeout=timeout)
         return struct.unpack(unpack_fmt, rx)
 
-    def _txrx_simple_packet(self, command: int, rx_len: int, timeout: float = 0.1) -> bytearray:
+    def _txrx_simple_packet(self, command: int, rx_len: int, timeout: Optional[float] = None) -> bytearray:
         """
         Transmits a simple command to the VEX device, performs the standard quality of message checks, then
         returns the payload.
@@ -47,12 +51,14 @@ class VEXDevice(GenericDevice):
             raise comm_error.VEXCommError("Received data doesn't match expected length", msg)
         return msg['payload']
 
-    def _rx_packet(self, timeout: float = 0.01) -> Dict[str, Union[Union[int, bytes, bytearray], Any]]:
+    def _rx_packet(self, timeout: Optional[float] = None) -> Dict[str, Union[Union[int, bytes, bytearray], Any]]:
         # Optimized to read as quickly as possible w/o delay
         start_time = time.time()
         response_header = bytes([0xAA, 0x55])
         response_header_stack = list(response_header)
         rx = bytearray()
+        if timeout is None:
+            timeout = self.default_timeout
         while (len(rx) > 0 or time.time() - start_time < timeout) and len(response_header_stack) > 0:
             b = self.port.read(1)
             if len(b) == 0:
@@ -66,7 +72,7 @@ class VEXDevice(GenericDevice):
                 response_header_stack = bytearray(response_header)
                 rx = bytearray()
         if not rx == bytearray(response_header):
-            raise IOError(f"Couldn't find the response header in the device response. "
+            raise IOError(f"Couldn't find the response header in the device response after {timeout} s. "
                           f"Got {rx.hex()} but was expecting {response_header.hex()}")
         rx.extend(self.port.read(1))
         command = rx[-1]
@@ -95,7 +101,7 @@ class VEXDevice(GenericDevice):
         return tx
 
     def _txrx_packet(self, command: int, tx_data: Union[Iterable, bytes, bytearray, None] = None,
-                     timeout: float = 0.1) -> Message:
+                     timeout: Optional[float] = None) -> Message:
         """
         Goes through a send/receive cycle with a VEX device.
         Transmits the command with the optional additional payload, then reads and parses the outer layer

--- a/pros/serial/ports/direct_port.py
+++ b/pros/serial/ports/direct_port.py
@@ -10,6 +10,7 @@ from .base_port import BasePort, PortConnectionException
 
 def create_serial_port(port_name: str, timeout: Optional[float] = 1.0) -> serial.Serial:
     try:
+        logger(__name__).debug(f'Opening serial port {port_name}')
         port = serial.Serial(port_name, baudrate=115200, bytesize=serial.EIGHTBITS,
                              parity=serial.PARITY_NONE, stopbits=serial.STOPBITS_ONE)
         port.timeout = timeout


### PR DESCRIPTION
#### Summary:
Adds support for wireless uploading. Specifically
 - [X] Enables joystick port detection
 - [X] Negotiation to dedicated download channel
  - Currently we just check if the connected to a controller, and always negotiate to download channel. We could be able to do a better job and only ask for transfer when we know we're communicating with the Brain over VEXnet and not on download channel. I'm not currently aware of how to query this info so it will have to wait
 - [X] Improved how timeout gets assigned when invoking commands. Now have the ability to change the default timeout instead of just letting default parameters fall through. This is useful since we need to increase the timeout of everything when communicating wirelessly.

#### Motivation:
Everyone and their mother wants this

#### Impact:
Wireless upload is slow and PROS binaries are relatively large considering the bandwidth when uploading wirelessly.

#46, purduesigbots/pros#89 all aim to address this

##### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->

#### Test Plan:
- [X] Upload kernel project wirelessly (albeit slowly)
- [X] Upload kernel project over the wire
- [x] Upload hot ~/cold~ Forkner wirelessly
- [ ] Upload hot ~/cold~ Rogers wirelessly
- [x] Upload a project via V5 Controller through smart port
- [X] `prosv5 lsusb` shows controller as a system port
- [X] Large files get a prompt to make sure you want to upload