### PR TITLE
⚡ Add V5 upload compression

### DIFF
--- a/pros/cli/upload.py
+++ b/pros/cli/upload.py
@@ -31,6 +31,8 @@ def upload_cli():
               cls=PROSOption, group='V5 Options', help='Open "run program" screen after uploading, instead of executing'
                                                        ' program. This option may help with controller connectivity '
                                                        'reliability and prevent robots from running off tables.')
+@click.option('--compress-bin/--no-compress-bin', 'compress_bin', cls=PROSOption, group='V5 Options', default=True,
+              help='Compress the program binary before uploading.')
 @default_options
 def upload(path: str, project: Optional[c.Project], port: str, **kwargs):
     """
@@ -94,7 +96,8 @@ def upload(path: str, project: Optional[c.Project], port: str, **kwargs):
         pass
 
     # print what was decided
-    ui.echo('Uploading {} to {} device on {}'.format(path, kwargs['target'], port), nl=False)
+    compressed_label = ' (compressed) ' if kwargs['compress_bin'] else ' '
+    ui.echo(f"Uploading {path}{compressed_label}to {kwargs['target']} device on {port}", nl=False)
     if kwargs['target'] == 'v5':
         ui.echo(f' as {args[0]} to slot {kwargs["slot"] + 1}', nl=False)
     ui.echo('')

--- a/pros/common/ui/__init__.py
+++ b/pros/common/ui/__init__.py
@@ -85,7 +85,7 @@ def progressbar(iterable: Iterable = None, length: int = None, label: str = None
                 fill_char: str = '#', empty_char: str = '-', bar_template: str = '%(label)s [%(bar)s] %(info)s',
                 info_sep: str = ' ', width: int = 36):
     if ismachineoutput():
-        return _MachineOutputProgessBar(**locals())
+        return _MachineOutputProgressBar(**locals())
     else:
         return click.progressbar(**locals())
 
@@ -134,18 +134,18 @@ def finalize(method: str, data: Union[str, Dict, object, List[Union[str, Dict, o
         click.echo(human_readable)
 
 
-class _MachineOutputProgessBar(_click_ProgressBar):
+class _MachineOutputProgressBar(_click_ProgressBar):
     def __init__(self, *args, **kwargs):
         global _current_notify_value
         kwargs['file'] = open(os.devnull, 'w')
         self.notify_value = kwargs.pop('notify_value', _current_notify_value)
-        super(_MachineOutputProgessBar, self).__init__(*args, **kwargs)
+        super(_MachineOutputProgressBar, self).__init__(*args, **kwargs)
 
     def __del__(self):
         self.file.close()
 
     def render_progress(self):
-        super(_MachineOutputProgessBar, self).render_progress()
+        super(_MachineOutputProgressBar, self).render_progress()
         obj = {'text': self.label, 'pct': self.pct}
         if self.show_eta and self.eta_known and not self.finished:
             obj['eta'] = self.eta

--- a/pros/conductor/project.py
+++ b/pros/conductor/project.py
@@ -66,6 +66,7 @@ class Project(Config):
                        remove_empty_directories: bool = False):
         """
         Applies a template to a project
+        :param remove_empty_directories:
         :param template:
         :param force_system:
         :param force_user:
@@ -204,12 +205,15 @@ class Project(Config):
             build_args = [*build_args, f'BINDIR={td_path}']
 
         def libscanbuild_capture(args: argparse.Namespace) -> Tuple[int, Iterable[Compilation]]:
+            """
+            Implementation of compilation database generation.
+
+            :param args:    the parsed and validated command line arguments
+            :return:        the exit status of build process.
+            """
             from libscanbuild.intercept import setup_environment, run_build, exec_trace_files, parse_exec_trace, \
                 compilations
             from libear import temporary_directory
-            """ Implementation of compilation database generation.
-            :param args:    the parsed and validated command line arguments
-            :return:        the exit status of build process. """
 
             with temporary_directory(prefix='intercept-') as tmp_dir:
                 # run the build command

--- a/pros/serial/devices/vex/v5_device.py
+++ b/pros/serial/devices/vex/v5_device.py
@@ -135,20 +135,23 @@ class V5Device(VEXDevice, SystemDevice):
         ini_file = self.generate_ini_file(remote_name=remote_name, slot=slot, ini=ini, **kwargs)
         logger(__name__).info(f'Created ini: {ini_file}')
 
+        should_compress_bin = kwargs.pop('compress_bin', False)
         if (quirk & 0xff) == 1:
             # WRITE BIN FILE
-            self.write_file(file, f'{remote_base}.bin', file_len=file_len, type='bin', run_after=run_after, **kwargs)
+            self.write_file(file, f'{remote_base}.bin', file_len=file_len, type='bin', run_after=run_after,
+                            compress_bin=should_compress_bin, **kwargs)
             with BytesIO(ini_file.encode(encoding='ascii')) as ini_bin:
                 # WRITE INI FILE
-                self.write_file(ini_bin, f'{remote_base}.ini', type='ini', **kwargs)
+                self.write_file(ini_bin, f'{remote_base}.ini', type='ini', compress_bin=False, **kwargs)
         elif (quirk & 0xff) == 0:
             # STOP PROGRAM
             self.execute_program_file('', run=False)
             with BytesIO(ini_file.encode(encoding='ascii')) as ini_bin:
                 # WRITE INI FILE
-                self.write_file(ini_bin, f'{remote_base}.ini', type='ini', **kwargs)
+                self.write_file(ini_bin, f'{remote_base}.ini', type='ini', compress_bin=False, **kwargs)
             # WRITE BIN FILE
-            self.write_file(file, f'{remote_base}.bin', file_len=file_len, type='bin', run_after=run_after, **kwargs)
+            self.write_file(file, f'{remote_base}.bin', file_len=file_len, type='bin', run_after=run_after,
+                            compress_bin=should_compress_bin, **kwargs)
         else:
             raise ValueError(f'Unknown quirk option: {quirk}')
 

--- a/pros/serial/devices/vex/v5_device.py
+++ b/pros/serial/devices/vex/v5_device.py
@@ -1,5 +1,3 @@
-import time
-
 import gzip
 import io
 import re

--- a/pros/serial/interactive/UploadProjectModal.py
+++ b/pros/serial/interactive/UploadProjectModal.py
@@ -74,6 +74,9 @@ class UploadProjectModal(application.Modal[None]):
                     ),
                     'description': parameters.Parameter(
                         self.project.upload_options.get('description', 'Created with PROS')
+                    ),
+                    'compress_bin': parameters.BooleanParameter(
+                        self.project.upload_options.get('compress_bin', True)
                     )
                 }
             else:
@@ -93,6 +96,7 @@ class UploadProjectModal(application.Modal[None]):
             kwargs['name'] = self.advanced_options['name'].value
             kwargs['slot'] = self.advanced_options['slot'].value
             kwargs['description'] = self.advanced_options['description'].value
+            kwargs['compress_bin'] = self.advanced_options['compress_bin'].value
         self.exit()
         get_current_context().invoke(upload, **kwargs)
 
@@ -118,5 +122,6 @@ class UploadProjectModal(application.Modal[None]):
                 components.InputBox('Program Name', self.advanced_options['name']),
                 components.InputBox('Slot', self.advanced_options['slot']),
                 components.InputBox('Description', self.advanced_options['description']),
+                components.Checkbox('Compress Binary', self.advanced_options['compress_bin']),
                 title='Advanced V5 Options',
                 collapsed=self.advanced_options_collapsed)


### PR DESCRIPTION
#### Summary:
<!-- Provide a concise description of your changes -->
Adds a new option for uploading binaries to the V5:

```
$ prosv5 u --compress-bin
```

The default value is true (and can be switched off with `--no-compress-bin`). When compression is enabled, .bin files to be uploaded are first compressed with gzip, which is supported natively on the V5.

(there is a side change included with this PR that adds a missing letter to the name of an internally used class)

#### Motivation:
<!-- Provide a brief description of why you think these changes need to be made -->
One of a series of PRs aimed at improving speed and reliability of wireless uploading.

##### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->
Together with #46, this blocks #47 

#### Test Plan:
<!-- Provide a list of steps that can be taken to verify these changes work as intended -->
- [x]  run prosv5 u (targeting a v5). bin/output.compressed.bin should be created, and it should have uploaded successfully
- [x] run prosv5 u --no-compress-bin (targeting a v5). only the normal bin/output.bin should be uploaded
- [x] run prosv5 u (targeting a cortex). nothing out of the ordinary should happen. Tested both with explicit `prosv5 u --compress-bin` and `prosv5 u --no-compress-bin`
- [x] Test compression checkbox in interactive upload modal