### PR TITLE
🐛 Revert Terminal changes in #38

### DIFF
--- a/pros/serial/terminal/terminal.py
+++ b/pros/serial/terminal/terminal.py
@@ -80,7 +80,7 @@ if os.name == 'nt':  # noqa
 
     class Console(ConsoleBase):
         def __init__(self):
-            super(ConsoleBase, self).__init__()
+            super(Console, self).__init__()
             self._saved_ocp = ctypes.windll.kernel32.GetConsoleOutputCP()
             self._saved_icp = ctypes.windll.kernel32.GetConsoleCP()
             ctypes.windll.kernel32.SetConsoleOutputCP(65001)
@@ -123,7 +123,7 @@ elif os.name == 'posix':
 
     class Console(ConsoleBase):
         def __init__(self):
-            super(ConsoleBase, self).__init__()
+            super(Console, self).__init__()
             self.fd = sys.stdin.fileno()
             # an additional pipe is used in getkey, so that the cancel method
             # can abort the waiting getkey method


### PR DESCRIPTION
#### Summary:
I broke the terminal with these changes in #38.

#### Motivation:
It don't work for Jonathan. I didn't observe this when testing with my install. Not sure why it's broken on Linux but not Windows. Anywho, I just reverted the changes for both platforms since it wasn't broken to begin with.

##### References (optional):
N/A

#### Test Plan:
- [X] It work for Jonathan (on Linux)
- [X] It work for me (on Windows)
- [x] It work for someone else on Windows
