### PR TITLE
♻ Shadow upload command in upload-terminal

### DIFF
--- a/pros/cli/upload.py
+++ b/pros/cli/upload.py
@@ -172,5 +172,5 @@ def ls_usb(target):
 @click.pass_context
 def make_upload_terminal(ctx, **upload_kwargs):
     from .terminal import terminal
-    ctx.forward(upload, **upload_kwargs)
-    ctx.forward(terminal, request_banner=False)
+    ctx.invoke(upload, **upload_kwargs)
+    ctx.invoke(terminal, request_banner=False)

--- a/pros/cli/upload.py
+++ b/pros/cli/upload.py
@@ -168,8 +168,9 @@ def ls_usb(target):
 
 
 @upload_cli.command('upload-terminal', aliases=['ut'], hidden=True)
+@shadow_command(upload)
 @click.pass_context
-def make_upload_terminal(ctx):
+def make_upload_terminal(ctx, **upload_kwargs):
     from .terminal import terminal
-    ctx.forward(upload)
+    ctx.forward(upload, **upload_kwargs)
     ctx.forward(terminal, request_banner=False)


### PR DESCRIPTION
#### Summary:
Shadow the upload command arguments on `prosv5 ut`. We migrated to this behavior in 048124667863189baf045fc7164b1f7d8524c766, but skipped over this command by accident.

#### Motivation:
This fixes Alex's comment about upload-terminal breaking

##### References (optional):
N/A

#### Test Plan:
- [x] `prosv5 ut` now works
- [x] `prosv5 ut` now works on @HotelCalifornia's computer
