### PR TITLE
🚸 Add default directory support to NewProjectModal

### DIFF
--- a/pros/cli/interactive.py
+++ b/pros/cli/interactive.py
@@ -1,5 +1,6 @@
+import os
 from typing import *
-
+import click
 import pros.conductor as c
 from .common import PROSGroup, default_options, project_option, pros_root
 
@@ -16,11 +17,12 @@ def interactive():
 
 
 @interactive.command()
+@click.option('--directory', default=os.path.join(os.path.expanduser('~'), 'My PROS Project'))
 @default_options
-def new_project():
+def new_project(directory):
     from pros.common.ui.interactive.renderers import MachineOutputRenderer
     from pros.conductor.interactive.NewProjectModal import NewProjectModal
-    app = NewProjectModal()
+    app = NewProjectModal(directory=directory)
     MachineOutputRenderer(app).run()
 
 

--- a/pros/conductor/interactive/NewProjectModal.py
+++ b/pros/conductor/interactive/NewProjectModal.py
@@ -10,7 +10,6 @@ from .parameters import NonExistentProjectParameter
 
 
 class NewProjectModal(application.Modal[None]):
-    directory = NonExistentProjectParameter(os.path.join(os.path.expanduser('~'), 'My PROS Project'))
     targets = parameters.OptionParameter('v5', ['v5', 'cortex'])
     kernel_versions = parameters.OptionParameter('latest', ['latest'])
     install_default_libraries = parameters.BooleanParameter(True)
@@ -18,10 +17,12 @@ class NewProjectModal(application.Modal[None]):
     project_name = parameters.Parameter(None)
     advanced_collapsed = parameters.BooleanParameter(True)
 
-    def __init__(self, ctx: Context = None, conductor: Optional[Conductor] = None):
+    def __init__(self, ctx: Context = None, conductor: Optional[Conductor] = None,
+                 directory=os.path.join(os.path.expanduser('~'), 'My PROS Project')):
         super().__init__('Create a new project')
         self.conductor = conductor or Conductor()
         self.click_ctx = ctx or get_current_context()
+        self.directory = NonExistentProjectParameter(directory)
 
         cb = self.targets.on_changed(self.target_changed, asynchronous=True)
         cb(self.targets)

--- a/pros/conductor/interactive/UpdateProjectModal.py
+++ b/pros/conductor/interactive/UpdateProjectModal.py
@@ -62,7 +62,7 @@ class UpdateProjectModal(application.Modal[None]):
 
         self.project: Optional[Project] = project
         self.project_path = ExistingProjectParameter(
-            project.location if project else os.path.join(os.path.expanduser('~'), 'My PROS Project')
+            str(project.location) if project else os.path.join(os.path.expanduser('~'), 'My PROS Project')
         )
 
         self.name = parameters.Parameter(None)

--- a/pros/serial/interactive/UploadProjectModal.py
+++ b/pros/serial/interactive/UploadProjectModal.py
@@ -18,7 +18,7 @@ class UploadProjectModal(application.Modal[None]):
 
         self.project: Optional[Project] = project
         self.project_path = ExistingProjectParameter(
-            project.location if project else os.path.join(os.path.expanduser('~'), 'My PROS Project')
+            str(project.location) if project else os.path.join(os.path.expanduser('~'), 'My PROS Project')
         )
 
         self.port = parameters.OptionParameter('', [''])


### PR DESCRIPTION
#### Summary:
Adds support for overriding the default directory from being ~/My PROS Project

#### Motivation:
It'd be nice to not have the default directory be always ~/My PROS Project

##### References (optional):
purduesigbots/pros-cli-middleware#6

#### Test Plan:
- [X] Initial directory is different
