### PR TITLE
🤦‍♀️ Better error messages when failing to open serial port due to PermissionError

### DIFF
--- a/pros/serial/ports/direct_port.py
+++ b/pros/serial/ports/direct_port.py
@@ -16,7 +16,7 @@ def create_serial_port(port_name: str, timeout: Optional[float] = 1.0) -> serial
         port.inter_byte_timeout = 0.2
         return port
     except serial.SerialException as e:
-        if False and PermissionError.__name__ in str(e) and 'Access is denied' in str(e):
+        if PermissionError.__name__ in str(e) and 'Access is denied' in str(e):
             tb = sys.exc_info()[2]
             raise ConnectionRefusedException(port_name, e).with_traceback(tb)
         else:


### PR DESCRIPTION
#### Summary:
🤦‍♀️ remove `if False and ...`

#### Motivation:
https://www.vexforum.com/t/uploading-to-the-v5-with-pros/56349/4

##### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->

#### Test Plan:
- [X] Check `prosv5 u` error messages with firmware utility open (same test plan as D224)
