### PR TITLE
🐛 Conductor Improvements

### DIFF
--- a/pros/conductor/conductor.py
+++ b/pros/conductor/conductor.py
@@ -213,7 +213,7 @@ class Conductor(Config):
                                     remove_empty_directories=remove_empty_directories)
 
     def new_project(self, path: str, no_default_libs: bool = False, **kwargs) -> Project:
-        if Path(path).samefile(os.path.expanduser('~')):
+        if Path(path).exists() and Path(path).samefile(os.path.expanduser('~')):
             raise dont_send(ValueError('Will not create a project in user home directory'))
         proj = Project(path=path, create=True)
         if 'target' in kwargs:

--- a/pros/conductor/conductor.py
+++ b/pros/conductor/conductor.py
@@ -1,5 +1,6 @@
 import os.path
 import shutil
+from pathlib import Path
 from typing import *
 
 import click
@@ -212,6 +213,8 @@ class Conductor(Config):
                                     remove_empty_directories=remove_empty_directories)
 
     def new_project(self, path: str, no_default_libs: bool = False, **kwargs) -> Project:
+        if Path(path).samefile(os.path.expanduser('~')):
+            raise dont_send(ValueError('Will not create a project in user home directory'))
         proj = Project(path=path, create=True)
         if 'target' in kwargs:
             proj.target = kwargs['target']

--- a/pros/conductor/interactive/parameters.py
+++ b/pros/conductor/interactive/parameters.py
@@ -1,5 +1,6 @@
 import os.path
 import sys
+from pathlib import Path
 from typing import *
 
 from semantic_version import Spec, Version
@@ -26,6 +27,8 @@ class NonExistentProjectParameter(p.ValidatableParameter[str]):
             ])
         if any(value.startswith(d) for d in blacklisted_directories):
             return 'Cannot create project in a system directory'
+        if Path(value).samefile(os.path.expanduser('~')):
+            return 'Should not create a project in home directory'
         if not os.path.exists(value):
             parent = os.path.split(value)[0]
             while parent and not os.path.exists(parent):

--- a/pros/conductor/interactive/parameters.py
+++ b/pros/conductor/interactive/parameters.py
@@ -27,7 +27,7 @@ class NonExistentProjectParameter(p.ValidatableParameter[str]):
             ])
         if any(value.startswith(d) for d in blacklisted_directories):
             return 'Cannot create project in a system directory'
-        if Path(value).samefile(os.path.expanduser('~')):
+        if Path(value).exists() and Path(value).samefile(os.path.expanduser('~')):
             return 'Should not create a project in home directory'
         if not os.path.exists(value):
             parent = os.path.split(value)[0]

--- a/pros/conductor/templates/template.py
+++ b/pros/conductor/templates/template.py
@@ -9,9 +9,9 @@ class Template(BaseTemplate):
     def __init__(self, **kwargs):
         self.system_files: List[str] = []
         self.user_files: List[str] = []
-        if 'version' in kwargs:
-            kwargs['version'] = str(Version.coerce(kwargs['version']))
         super().__init__(**kwargs)
+        if self.version:
+            self.version = str(Version.coerce(self.version))
 
     @property
     def all_files(self) -> Set[str]:

--- a/pros/conductor/templates/template.py
+++ b/pros/conductor/templates/template.py
@@ -1,5 +1,7 @@
 from typing import *
 
+from semantic_version import Version
+
 from .base_template import BaseTemplate
 
 
@@ -7,6 +9,8 @@ class Template(BaseTemplate):
     def __init__(self, **kwargs):
         self.system_files: List[str] = []
         self.user_files: List[str] = []
+        if 'version' in kwargs:
+            kwargs['version'] = str(Version.coerce(kwargs['version']))
         super().__init__(**kwargs)
 
     @property


### PR DESCRIPTION
#### Summary:
- Prevent users from creating projects in home directory
- Coerce version strings into semantic version strings, rather than just assume they're semver

#### Motivation:
User reports

##### References (optional):
- Closes #64
- Closes #65

#### Test Plan:
<!-- Provide a list of steps that can be taken to verify these changes work as intended -->

- [X] Interactive prompt prevents users from creating project in home directory
- [x] CLI prevents users from creating project in home directory
- [x] Can still create projects normally
- [x] Check that version string is coerced into semver string (per #64) when creating template
- [x] Check that version string is coerced into semver string when fetching a template without a semver string