### PR TITLE
🐧 ConnectionRefusedException for Linux as well

### DIFF
--- a/pros/serial/ports/direct_port.py
+++ b/pros/serial/ports/direct_port.py
@@ -3,7 +3,7 @@ from typing import *
 
 import serial
 
-from pros.common import logger
+from pros.common import logger, dont_send
 from pros.serial.ports.exceptions import ConnectionRefusedException
 from .base_port import BasePort, PortConnectionException
 
@@ -16,9 +16,11 @@ def create_serial_port(port_name: str, timeout: Optional[float] = 1.0) -> serial
         port.inter_byte_timeout = 0.2
         return port
     except serial.SerialException as e:
-        if PermissionError.__name__ in str(e) and 'Access is denied' in str(e):
+        if any(msg in str(e) for msg in [
+            'Access is denied', 'Errno 16', 'Errno 13'
+        ]):
             tb = sys.exc_info()[2]
-            raise ConnectionRefusedException(port_name, e).with_traceback(tb)
+            raise dont_send(ConnectionRefusedException(port_name, e).with_traceback(tb))
         else:
             raise e
 

--- a/pros/serial/ports/exceptions.py
+++ b/pros/serial/ports/exceptions.py
@@ -1,8 +1,15 @@
+import os
+
+
 class ConnectionRefusedException(IOError):
     def __init__(self, port_name: str, reason: Exception):
         self.__cause__ = reason
         self.port_name = port_name
 
     def __str__(self):
+        extra = ''
+        if os.name == 'posix':
+            extra = 'adding yourself to dialout group '
         return f"could not open port '{self.port_name}'. Try closing any other VEX IDEs such as ROBOTC, VCS, or " \
-               f"firmware utilities; moving to a different USB port; or restarting the device."
+            f"firmware utilities; moving to a different USB port; {extra}or " \
+            f"restarting the device."


### PR DESCRIPTION
#### Summary:
Detect Linux conditions for ConnectionRefusedException when trying to open the serial port

#### Motivation:
Better error messages that won't get sent to us in Sentry

##### References (optional):
Closes #45 

#### Test Plan:
- [x] Still works for Windows when Firmware Utility is open
- [x] See better error message when you're not part of dialout group
- [x] See better error message when you already have the port open
