### PR TITLE
😱 Fix screen capture (again)

### DIFF
--- a/pros/serial/devices/vex/v5_device.py
+++ b/pros/serial/devices/vex/v5_device.py
@@ -534,8 +534,8 @@ class V5Device(VEXDevice, SystemDevice):
             file, file_len = compress_file(file, file_len)
 
         if self.is_wireless and file_len > 0x25000:
-            confirm(f'You\'re about to upload {file_len} bytes wirelessly. This could take some time, and you should '
-                    f'consider uploading directly with a wire.', abort=True, default=False)
+            confirm(f'You\'re about to download {file_len} bytes wirelessly. This could take some time, and you should '
+                    f'consider downloading directly with a wire.', abort=True, default=False)
         crc32 = self.VEX_CRC32.compute(file.read(file_len))
         file.seek(0, 0)
         addr = kwargs.get('addr', 0x03800000)

--- a/pros/serial/devices/vex/v5_device.py
+++ b/pros/serial/devices/vex/v5_device.py
@@ -507,8 +507,8 @@ class V5Device(VEXDevice, SystemDevice):
             file_len = ft_meta['file_size']
 
         if self.is_wireless and file_len > 0x25000:
-            confirm(f'You\'re about to upload {file_len} bytes wirelessly. This could take some time, and you should '
-                    f'consider uploading directly with a wire.', abort=True, default=False)
+            confirm(f'You\'re about to download {file_len} bytes wirelessly. This could take some time, and you should '
+                    f'consider downloading directly with a wire.', abort=True, default=False)
 
         max_packet_size = ft_meta['max_packet_size']
         with ui.progressbar(length=file_len, label='Downloading {}'.format(remote_file)) as progress:
@@ -534,8 +534,8 @@ class V5Device(VEXDevice, SystemDevice):
             file, file_len = compress_file(file, file_len)
 
         if self.is_wireless and file_len > 0x25000:
-            confirm(f'You\'re about to download {file_len} bytes wirelessly. This could take some time, and you should '
-                    f'consider downloading directly with a wire.', abort=True, default=False)
+            confirm(f'You\'re about to upload {file_len} bytes wirelessly. This could take some time, and you should '
+                    f'consider uploading directly with a wire.', abort=True, default=False)
         crc32 = self.VEX_CRC32.compute(file.read(file_len))
         file.seek(0, 0)
         addr = kwargs.get('addr', 0x03800000)

--- a/pros/serial/devices/vex/v5_device.py
+++ b/pros/serial/devices/vex/v5_device.py
@@ -88,7 +88,7 @@ def with_download_channel(f):
 
     def wrapped(device, *args, **kwargs):
         with V5Device.DownloadChannel(device):
-            f(device, *args, **kwargs)
+            return f(device, *args, **kwargs)
 
     return wrapped
 
@@ -505,6 +505,11 @@ class V5Device(VEXDevice, SystemDevice):
         ft_meta = self.ft_initialize(remote_file, function='download', vid=vid, target=target)
         if file_len is None:
             file_len = ft_meta['file_size']
+
+        if self.is_wireless and file_len > 0x25000:
+            confirm(f'You\'re about to upload {file_len} bytes wirelessly. This could take some time, and you should '
+                    f'consider uploading directly with a wire.', abort=True, default=False)
+
         max_packet_size = ft_meta['max_packet_size']
         with ui.progressbar(length=file_len, label='Downloading {}'.format(remote_file)) as progress:
             for i in range(0, file_len, max_packet_size):


### PR DESCRIPTION
#### Summary:
- `with_wireless_download` wrapper no longer suppresses the return value of the wrapped function
- Also snuck in a change to prompt the user to confirm when reading a file wirelessly if it's big

#### Motivation:
- It broke (again)

##### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->

#### Test Plan:
- [X] Screen capture works again both wired and wirelessly
- [X] See confirmation to download screen capture wirelessly
