### PR TITLE
Clean up after all these merges

### DIFF
--- a/pros/serial/devices/vex/v5_device.py
+++ b/pros/serial/devices/vex/v5_device.py
@@ -657,7 +657,7 @@ class V5Device(VEXDevice, SystemDevice):
         tx_payload = struct.pack("<4B3I4s2I24s", options['function'], options['target'], options['vid'],
                                  options['options'], options['length'], options['addr'], options['crc'],
                                  options['type'], options['timestamp'], options['version'], options['name'])
-        rx = self._txrx_ext_struct(0x11, tx_payload, "<H2I")
+        rx = self._txrx_ext_struct(0x11, tx_payload, "<H2I", timeout=kwargs.get('timeout', self.default_timeout * 5))
         rx = dict(zip(['max_packet_size', 'file_size', 'crc'], rx))
         logger(__name__).debug('response: {}'.format(rx))
         logger(__name__).debug('Completed ext 0x11 command')
@@ -669,7 +669,7 @@ class V5Device(VEXDevice, SystemDevice):
         if isinstance(options, bool):
             options = self.FTCompleteOptions.RUN_IMMEDIATELY if options else self.FTCompleteOptions.DONT_RUN
         tx_payload = struct.pack("<B", options.value)
-        ret = self._txrx_ext_packet(0x12, tx_payload, 0, timeout=10.0)
+        ret = self._txrx_ext_packet(0x12, tx_payload, 0, timeout=self.default_timeout * 10)
         logger(__name__).debug('Completed ext 0x12 command')
         return ret
 

--- a/pros/serial/interactive/UploadProjectModal.py
+++ b/pros/serial/interactive/UploadProjectModal.py
@@ -127,7 +127,7 @@ class UploadProjectModal(application.Modal[None]):
         from click import get_current_context
         kwargs = {'path': None, 'project': self.project, 'port': self.port.value}
         if self.project.target == 'v5':
-            kwargs['name'] = self.advanced_options['name'].value
+            kwargs['remote_name'] = self.advanced_options['name'].value
             kwargs['slot'] = int(self.advanced_options['slot'].value[0])  # XXX: the first character is the slot number
             kwargs['description'] = self.advanced_options['description'].value
             kwargs['compress_bin'] = self.advanced_options['compress_bin'].value


### PR DESCRIPTION
#### Summary:
- Force program ini to be uploaded at default address
- Move wireless upload check before ft_initialize
- Ensure ft_read `n_bytes` is word aligned
- Improve default timeout for ft_initialize and ft_complete
- Only revert back to pit channel if switched
- Wrap high level V5 functions `with ui.Notification()`

#### Motivation:
Things broke from the mess of all these merges

##### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->

#### Test Plan:
- [X] Interactive upload modal works again
  - [X] slot list works
  - [X] Upload notification shows up
- [X] Screen capture still works
- [X] Upload from CLI still works (with hot/cold)
- [X] Upload from CLI still works (with monolith)
