### PR TITLE
🚸 Add ability to save upload options to project

### DIFF
--- a/pros/serial/interactive/UploadProjectModal.py
+++ b/pros/serial/interactive/UploadProjectModal.py
@@ -104,7 +104,7 @@ class UploadProjectModal(application.Modal[None]):
 
             if self.project.target == 'v5':
                 self.advanced_options = {
-                    'name': parameters.Parameter(self.project.name),
+                    'name': parameters.Parameter(self.project.upload_options.get('remote_name', self.project.name)),
                     'description': parameters.Parameter(
                         self.project.upload_options.get('description', 'Created with PROS')
                     ),
@@ -135,7 +135,6 @@ class UploadProjectModal(application.Modal[None]):
             savable_kwargs['compress_bin'] = self.advanced_options['compress_bin'].value
 
         if self.save_settings.value:
-            self.project.project_name = savable_kwargs['remote_name']
             self.project.upload_options.update(savable_kwargs)
             self.project.save()
 


### PR DESCRIPTION
#### Summary:
- Adds a checkbox component to the project upload modal that, when checked, will save to a project
  - the slot,
  - the remote name,
  - the description,
  - and whether or not to compress the binary before uploading

![screenshot of feature](https://puu.sh/CNQve/f8fbe6dafa.png)
relevant excerpt from project.pros file
```json
        "upload_options": {
            "compress_bin": true,
            "description": "guten abend schwester",
            "remote_name": "jernel-dove",
            "slot": 2
        }
```
#### Motivation:
This way people can enter their desired information once and not have to worry about entering it every time when uploading, as that would get tedious very quickly. 

##### References (optional):
Closes #53 

#### Test Plan:
- [x] uploading still works normally (without save box checked)
- [x] uploading without the save box checked does not overwrite settings for future uploads (and future uploads use previously saved settings, if any)
- [x] change fields in advanced options (savable ones listed above), then
 - [x] observe that they are saved to the `upload_options` key in project.pros files
 - [x] observe that the same values are used the next time the upload modal is opened
