### PR TITLE
🐛 Sort keys of cold hash

### DIFF
--- a/pros/serial/devices/vex/v5_device.py
+++ b/pros/serial/devices/vex/v5_device.py
@@ -218,7 +218,8 @@ class V5Device(VEXDevice, SystemDevice):
         keys.update(extra)
         from hashlib import md5
         from base64 import b64encode
-        name = b64encode(md5(str(keys).encode('ascii')).digest()).rstrip(b'=').decode('ascii')
+        msg = str(sorted(keys, key=lambda t: t[0])).encode('ascii')
+        name = b64encode(md5(msg).digest()).rstrip(b'=').decode('ascii')
         if Spec('<=1.0.0-27').match(self.status['cpu0_version']):
             # Bug prevents linked files from being > 18 characters long.
             # 17 characters is probably good enough for hash, so no need to fail out


### PR DESCRIPTION
#### Summary:
- Sort the keys that generate the cold hash so that it's hashing the way we want

#### Motivation:
Right now, we just hash in whatever order the dictionary of libraries happens to be. This will cause issues because `{"kernel": "3.1.6", "okapilib": "4.0.0"}` and `{"okapilib": "4.0.0", "kernel": "3.1.6"}` wouldn't be considered equivalent (even though they are)

##### References (optional):
None

#### Test Plan:
- [X] Can still upload
- [x] Maliciously changed the order of the dictionary in project.pros and it still worked fine
