### PR TITLE
🐛 Use sys.exit correctly

### DIFF
--- a/pros/cli/upload.py
+++ b/pros/cli/upload.py
@@ -1,3 +1,5 @@
+from sys import exit
+
 import pros.common.ui as ui
 import pros.conductor as c
 


### PR DESCRIPTION
#### Summary:
`from sys import exit` because it wasn't being done before.

#### Motivation:
Had a few Sentry reports about this.

##### References (optional):
N/A

#### Test Plan:
- [ ] Throwing an exception in that try/catch block no longer raises that exit exception
