### PR TITLE
Fix terminal input by calling ConsoleBase setup()/cleanup()

### DIFF
--- a/pros/serial/terminal/terminal.py
+++ b/pros/serial/terminal/terminal.py
@@ -275,12 +275,14 @@ class Terminal(object):
         self.no_sigint = False
 
     def start(self):
+        self.console.setup()
         self.alive.clear()
         self._start_rx()
         self._start_tx()
 
     # noinspection PyUnusedLocal
     def stop(self, *args):
+        self.console.cleanup()
         if not self.alive.is_set():
             logger(__name__).warning('Stopping terminal')
             self.alive.set()


### PR DESCRIPTION
#### Summary:
I added a call to `self.console.setup()` in `Terminal.start()`, and a call to `self.console.cleanup()` in `Terminal.stop()`. This disables echo and line editing in the terminal, letting the existing code in `Terminal.transmitter()` handle echoing. 

#### Motivation:
Without this, terminal input is pretty broken, at least on linux. Input behaves strangely, with the program receiving only the second-to-last line, the first character of an input line being echoed, and empty input lines being input immediately but double-printed. See ![image](https://i.imgur.com/P0p8JOI.png).

#### Test Plan:
- [X] Be able to input lines into the terminal as expected
- [ ] Be able to use backspace without it being sent to program