### PR TITLE
🐛 Fix bug in screen capture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dist/
 
 out/
 *.zip
+*_pros_capture.png
 
 venv/
 

--- a/pros/cli/v5_utils.py
+++ b/pros/cli/v5_utils.py
@@ -258,7 +258,7 @@ def capture(file_name: str, port: str, force: bool = False):
         return -1
 
     with open(file_name, 'wb') as file_:
-        w = png.Writer(width, height)
+        w = png.Writer(width, height, greyscale=False)
         w.write(file_, i_data)
 
     print(f'Saved screen capture to {file_name}')

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ scan-build==2.0.13
 rfc6266-parser
 sentry-sdk
 observable
-pypng
+pypng==0.0.20


### PR DESCRIPTION
This commit fixes screen capture and version pins pypng. Given that a breaking change was made to pypng without a bump in either major or minor version, I figured it better to pin the version than hope that no other breaking changes are made in future.

# Test plan:
* [x] Take a screenshot
