### PR TITLE
Fix wireless terminal (RX only)

### DIFF
--- a/pros/cli/common.py
+++ b/pros/cli/common.py
@@ -196,9 +196,11 @@ def pros_root(f):
 
 def resolve_v5_port(port: Optional[str], type: str, quiet: bool = False) -> Tuple[Optional[str], bool]:
     from pros.serial.devices.vex import find_v5_ports
+    # If a port is specified manually, we'll just assume it's
+    # not a joystick.
+    is_joystick = False
     if not port:
         ports = find_v5_ports(type)
-        is_joystick = False
         if len(ports) == 0:
             if not quiet:
                 logger(__name__).error('No {0} ports were found! If you think you have a {0} plugged in, '

--- a/pros/cli/upload.py
+++ b/pros/cli/upload.py
@@ -71,7 +71,7 @@ def upload(path: Optional[str], project: Optional[c.Project], port: str, **kwarg
         raise click.UsageError('Target not specified. specify a project (using the file argument) or target manually')
 
     if kwargs['target'] == 'v5':
-        port = resolve_v5_port(port, 'system')
+        port, is_joystick = resolve_v5_port(port, 'system')
     elif kwargs['target'] == 'cortex':
         port = resolve_cortex_port(port)
     else:

--- a/pros/serial/devices/vex/v5_device.py
+++ b/pros/serial/devices/vex/v5_device.py
@@ -161,6 +161,7 @@ class V5Device(VEXDevice, SystemDevice):
 
     def __init__(self, port: BasePort):
         self._status = None
+        self._serial_cache = b''
         super().__init__(port)
 
     class DownloadChannel(object):
@@ -831,18 +832,32 @@ class V5Device(VEXDevice, SystemDevice):
 
     @retries
     def user_fifo_read(self) -> bytes:
-        # read/write are the same command, behavior dictated by specifying payload
+        # I can't really think of a better way to only return when a full
+        # COBS message was written than to just cache the data until we hit a \x00.
+
+        # read/write are the same command, behavior dictated by specifying
+        # length-to-read as 0xFF and providing additional payload bytes to write or
+        # specifying a length-to-read and no additional data to read.
         logger(__name__).debug('Sending ext 0x27 command (read)')
-        # minimum size payload (2 checksum bytes) signifies a "read" operation
-        tx_payload = struct.pack("<4B", 0x02, self.channel_map['download'], 0x00)
-        # expected RX length arbitrary- we won't check the payload length as spec says it's variable (and there's no way
-        # to guess)
-        ret = self._txrx_ext_packet(0x27, tx_payload, 0, check_length=False)
+        # specifying a length to read (0x40 bytes) with no additional payload data.
+        tx_payload = struct.pack("<2B", self.channel_map['download'], 0x40)
+        # RX length isn't always 0x40 (end of buffer reached), so don't check_length.
+        self._serial_cache += self._txrx_ext_packet(0x27, tx_payload, 0, check_length=False)[1:]
         logger(__name__).debug('Completed ext 0x27 command (read)')
+        # if _serial_cache doesn't have a \x00, pretend we didn't read anything.
+        if b'\x00' not in self._serial_cache:
+            return b''
+        # _serial_cache has a \x00, split off the beginning part and hand it down.
+        parts = self._serial_cache.split(b'\x00')
+        ret = parts[0] + b'\x00'
+        self._serial_cache = b'\x00'.join(parts[1:])
+
         return ret
 
     @retries
     def user_fifo_write(self, payload: Union[Iterable, bytes, bytearray, str]):
+        # Not currently implemented
+        return
         logger(__name__).debug('Sending ext 0x27 command (write)')
         max_packet_size = 224
         pl_len = len(payload)
@@ -851,7 +866,7 @@ class V5Device(VEXDevice, SystemDevice):
             if i + max_packet_size > pl_len:
                 packet_size = pl_len - i
             logger(__name__).debug(f'Writing {packet_size} bytes to user FIFO')
-            self._txrx_ext_packet(0x27, payload[i:packet_size], packet_size)
+            self._txrx_ext_packet(0x27, b'\x01\x00' + payload[i:packet_size], 0, check_length=False)[1:]
         logger(__name__).debug('Completed ext 0x27 command (write)')
 
     @retries


### PR DESCRIPTION
#### Summary:
Fixed user_fifo_read by properly formatting the data required by the ext 0x27 command so that it would not fail with a General NACK, then adding a `_serial_cache` so that the terminal would only receive full COBS-decodable messages and not output "Could not decode bytes".

#### Motivation:
This change brings wireless terminal to PROS, a feature that's been present in VEXCode and RMS. This will allow for remote debugging of PROS programs.

##### References (optional):
This closes #94.

#### Test Plan:
- [x] Be able to read from terminal
- [ ] Be able to write to terminal (maybe not possible?)
