### PR TITLE
🐛 Fix channel switch timeout bug when uploading wirelessly

### DIFF
--- a/pros/serial/devices/vex/v5_device.py
+++ b/pros/serial/devices/vex/v5_device.py
@@ -176,6 +176,7 @@ class V5Device(VEXDevice, SystemDevice):
                     raise VEXCommError('V5 Controller doesn\'t appear to be connected to a V5 Brain', version)
                 ui.echo('Transferring V5 to download channel')
                 self.device.ft_transfer_channel('download')
+                self.did_switch = True
                 logger(__name__).debug('Sleeping for a while to let V5 start channel transfer')
                 time.sleep(.25)  # wait at least 250ms before starting to poll controller if it's connected yet
                 version = self.device.query_system_version()


### PR DESCRIPTION
#### Summary:
Sets the did_switch variable to true after switching to the download channel.

#### Motivation:
Wasting time resetting the field every time we get 2/3 of the way through our auton.

##### References (optional):
Fixes: [#112](https://github.com/purduesigbots/pros-cli/issues/112)

#### Test Plan:

1. I verified the bug existed in the current build by downloading and building the current develop branch.
2. Building and uploading a project produced the issue.
3. Made the change than built and tried uploading the same project again.
4. It produced the expected result.
