### PR TITLE
🐛 Get slot from project file

### DIFF
--- a/pros/cli/upload.py
+++ b/pros/cli/upload.py
@@ -21,7 +21,7 @@ def upload_cli():
 @click.option('-q', '--quirk', type=int, default=0)
 @click.option('--name', 'remote_name', type=str, default=None, required=False, help='Remote program name',
               cls=PROSOption, group='V5 Options')
-@click.option('--slot', default=1, show_default=True, type=click.IntRange(min=1, max=8), help='Program slot on the GUI',
+@click.option('--slot', default=None, type=click.IntRange(min=1, max=8), help='Program slot on the GUI',
               cls=PROSOption, group='V5 Options')
 @click.option('--program-version', default=None, type=str, help='Specify version metadata for program',
               cls=PROSOption, group='V5 Options', hidden=True)
@@ -83,6 +83,16 @@ def upload(path: Optional[str], project: Optional[c.Project], port: str, **kwarg
         raise dont_send(click.UsageError('No port provided or located. Make sure to specify --target if needed.'))
 
     if kwargs['target'] == 'v5':
+        slot = kwargs.get('slot', None)
+        if (slot == None):
+            try:
+                project_file = open(str(project.location)+"/project.pros", 'r')
+                import json
+                project_file_json = json.loads(project_file.read())
+                kwargs['slot'] = project_file_json['py/state']['upload_options']['slot']
+            except Exception:
+                kwargs['slot'] = 1
+                               
         if kwargs['remote_name'] is None:
             kwargs['remote_name'] = os.path.splitext(os.path.basename(path))[0]
         kwargs['remote_name'] = kwargs['remote_name'].replace('@', '_')

--- a/pros/cli/upload.py
+++ b/pros/cli/upload.py
@@ -60,6 +60,11 @@ def upload(path: Optional[str], project: Optional[c.Project], port: str, **kwarg
 
         # apply upload_options as a template
         options = dict(**project.upload_options)
+        if 'slot' in options and kwargs.get('slot', None) is None:
+            kwargs.pop('slot')
+        elif kwargs.get('slot', None) is None: 
+            kwargs['slot'] = 1
+            
         options.update(kwargs)
         kwargs = options
 

--- a/pros/cli/upload.py
+++ b/pros/cli/upload.py
@@ -88,16 +88,6 @@ def upload(path: Optional[str], project: Optional[c.Project], port: str, **kwarg
         raise dont_send(click.UsageError('No port provided or located. Make sure to specify --target if needed.'))
 
     if kwargs['target'] == 'v5':
-        slot = kwargs.get('slot', None)
-        if (slot == None):
-            try:
-                project_file = open(str(project.location)+"/project.pros", 'r')
-                import json
-                project_file_json = json.loads(project_file.read())
-                kwargs['slot'] = project_file_json['py/state']['upload_options']['slot']
-            except Exception:
-                kwargs['slot'] = 1
-                               
         if kwargs['remote_name'] is None:
             kwargs['remote_name'] = os.path.splitext(os.path.basename(path))[0]
         kwargs['remote_name'] = kwargs['remote_name'].replace('@', '_')


### PR DESCRIPTION
#### Summary:
Gets the slot value from the project.pros file if not supplied from command line.

#### Motivation:
Found an issue that looked useful to people who use multiple projects at once.
E.g. having a different project for each autonomous.
 
##### References:
Fixes: https://github.com/purduesigbots/pros-cli/issues/110

#### Test Plan:
Add `, "upload_options": {"slot": 4}` to the end of your project.pros file.
The end of your project file should look like this.
 `"version": "4.0.3"}}, "upload_options": {"slot": 4}}}`

And run `prosv5 upload` booth with and without the `--slot` option.