### PR TITLE
🔧 rename dist pros-cli-v5 -> pros-cli

### DIFF
--- a/build.py
+++ b/build.py
@@ -40,7 +40,7 @@ else:
     extension = ''
 
 setup(
-    name='pros-cli-v5',
+    name='pros-cli',
     version=open('pip_version').read().strip(),
     packages=modules,
     url='https://github.com/purduesigbots/pros-cli',
@@ -50,9 +50,10 @@ setup(
     description='Command Line Interface for managing PROS projects',
     options={"build_exe": build_exe_options, 'bdist_mac': build_mac_options},
     install_requires=install_reqs,
-    executables=[Executable('pros/cli/main.py', targetName=f'prosv5{extension}'),
-                 Executable('pros/cli/compile_commands/intercept-cc.py', targetName=f'intercept-cc{extension}'),
-                 Executable('pros/cli/compile_commands/intercept-cc.py', targetName=f'intercept-c++{extension}')]
+    executables=[Executable('pros/cli/main.py', target_name=f'pros{extension}'),
+                 Executable('pros/cli/main.py', target_name=f'prosv5{extension}'),
+                 Executable('pros/cli/compile_commands/intercept-cc.py', target_name=f'intercept-cc{extension}'),
+                 Executable('pros/cli/compile_commands/intercept-cc.py', target_name=f'intercept-c++{extension}')]
 )
 
 if sys.argv[1] == 'build_exe':

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,10 @@ setup(
     author_email='pros_development@cs.purdue.edu',
     description='Command Line Interface for managing PROS projects',
     install_requires=install_reqs,
-    entry_points="""
-        [console_scripts]
-        pros=pros.cli.main:main
-        prosv5=pros.cli.main:main
-        """
+    entry_points={
+        'console_scripts': [
+            'pros=pros.cli.main:main',
+            'prosv5=pros.cli.main:main'
+        ]
+    }
 )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 from install_requires import install_requires as install_reqs
 
 setup(
-    name='pros-cli-v5',
+    name='pros-cli',
     version=open('pip_version').read().strip(),
     packages=find_packages(),
     url='https://github.com/purduesigbots/pros-cli',
@@ -15,6 +15,7 @@ setup(
     install_requires=install_reqs,
     entry_points="""
         [console_scripts]
+        pros=pros.cli.main:main
         prosv5=pros.cli.main:main
         """
 )


### PR DESCRIPTION
#### Summary:
<!-- Provide a concise description of your changes -->
Changes the python distribution name from pros-cli-v5 back to pros-cli (and makes sure that both `pros` and `prosv5` are exposed as console commands)

#### Motivation:
<!-- Provide a brief description of why you think these changes need to be made -->
Finally....
This will also allow us to put our releases on PyPi and let users finally go (back) to using `pros` as a command instead of `prosv5`. 

It's only been like 3 years in the making

##### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->

#### Test Plan:
<!-- Provide a list of steps that can be taken to verify these changes work as intended -->

- [x] build
- [x] install
  - [x] `pros` and `prosv5` shims both present post-install
- [x] run
