### PR TITLE
🚸Schema Length Detection Change

### DIFF
--- a/pros/serial/devices/vex/v5_device.py
+++ b/pros/serial/devices/vex/v5_device.py
@@ -825,6 +825,7 @@ class V5Device(VEXDevice, SystemDevice):
 
     @retries
     def get_system_status(self) -> SystemStatus:
+        from semantic_version import Version
         logger(__name__).debug('Sending ext 0x22 command')
         if self.query_system_version().system_version < Version('1.0.13-0'):
             schema = '<x12B3xBI12x'

--- a/pros/serial/devices/vex/v5_device.py
+++ b/pros/serial/devices/vex/v5_device.py
@@ -905,9 +905,9 @@ class V5Device(VEXDevice, SystemDevice):
         if len(msg) > 0:
             logger(cls).debug('Set msg window to {}'.format(bytes_to_str(msg)))
         if len(msg) < rx_length and check_length:
-            raise VEXCommError("Received length is less than {} (got {})".format(rx_length, len(msg)), msg)
+            raise VEXCommError(f'Received length is less than {rx_length} (got {len(msg)})', msg)
         elif len(msg) > rx_length and check_length:
-            ui.echo("WARNING: Recieved length is more than {} (got {}). Consider upgrading the PROS (CLI Version: {}).".format(rx_length, len(msg),get_version()))
+            ui.echo(f'WARNING: Recieved length is more than {rx_length} (got {len(msg)}). Consider upgrading the PROS (CLI Version: {get_version()}).')
         return msg
 
     def _txrx_ext_packet(self, command: int, tx_data: Union[Iterable, bytes, bytearray],

--- a/pros/serial/devices/vex/v5_device.py
+++ b/pros/serial/devices/vex/v5_device.py
@@ -826,7 +826,7 @@ class V5Device(VEXDevice, SystemDevice):
     @retries
     def get_system_status(self) -> SystemStatus:
         logger(__name__).debug('Sending ext 0x22 command')
-        if self.query_system_version().system_version < semantic_version.Version('1.0.13'):
+        if str(self.query_system_version().system_version) < ('1.0.13-0'):
             schema = '<x12B3xBI12x'
         else:
             schema = '<x12B3xBI12xB3x'

--- a/pros/serial/devices/vex/v5_device.py
+++ b/pros/serial/devices/vex/v5_device.py
@@ -826,7 +826,7 @@ class V5Device(VEXDevice, SystemDevice):
     @retries
     def get_system_status(self) -> SystemStatus:
         logger(__name__).debug('Sending ext 0x22 command')
-        if str(self.query_system_version().system_version) < ('1.0.13-0'):
+        if self.query_system_version().system_version < Version('1.0.13-0'):
             schema = '<x12B3xBI12x'
         else:
             schema = '<x12B3xBI12xB3x'

--- a/pros/serial/devices/vex/v5_device.py
+++ b/pros/serial/devices/vex/v5_device.py
@@ -904,8 +904,10 @@ class V5Device(VEXDevice, SystemDevice):
             msg = msg[1:]
         if len(msg) > 0:
             logger(cls).debug('Set msg window to {}'.format(bytes_to_str(msg)))
-        if len(msg) != rx_length and check_length:
-            raise VEXCommError("Received length doesn't match {} (got {})".format(rx_length, len(msg)), msg)
+        if len(msg) < rx_length and check_length:
+            raise VEXCommError("Received length is less than {} (got {})".format(rx_length, len(msg)), msg)
+        elif len(msg) > rx_length and check_length:
+            ui.echo("WARNING: Recieved length is more than {} (got {}). Consider upgrading the PROS (CLI Version: {}).".format(rx_length, len(msg),self.query_system_version().system_version))
         return msg
 
     def _txrx_ext_packet(self, command: int, tx_data: Union[Iterable, bytes, bytearray],

--- a/pros/serial/devices/vex/v5_device.py
+++ b/pros/serial/devices/vex/v5_device.py
@@ -907,7 +907,7 @@ class V5Device(VEXDevice, SystemDevice):
         if len(msg) < rx_length and check_length:
             raise VEXCommError("Received length is less than {} (got {})".format(rx_length, len(msg)), msg)
         elif len(msg) > rx_length and check_length:
-            ui.echo("WARNING: Recieved length is more than {} (got {}). Consider upgrading the PROS (CLI Version: {}).".format(rx_length, len(msg),self.query_system_version().system_version))
+            ui.echo("WARNING: Recieved length is more than {} (got {}). Consider upgrading the PROS (CLI Version: {}).".format(rx_length, len(msg),get_version()))
         return msg
 
     def _txrx_ext_packet(self, command: int, tx_data: Union[Iterable, bytes, bytearray],

--- a/pros/serial/devices/vex/v5_device.py
+++ b/pros/serial/devices/vex/v5_device.py
@@ -826,7 +826,11 @@ class V5Device(VEXDevice, SystemDevice):
     @retries
     def get_system_status(self) -> SystemStatus:
         logger(__name__).debug('Sending ext 0x22 command')
-        rx = self._txrx_ext_struct(0x22, [], "<x12B3xBI12x")
+        if self.query_system_version().system_version < semantic_version.Version('1.0.13'):
+            schema = '<x12B3xBI12x'
+        else:
+            schema = '<x12B3xBI12xB3x'
+        rx = self._txrx_ext_struct(0x22, [], schema)
         logger(__name__).debug('Completed ext 0x22 command')
         return V5Device.SystemStatus(rx)
 


### PR DESCRIPTION
#### Summary:
This PR attempts to future proof schema in the case that VEX increases the length. Instead of NACKing when the schema is larger than the length, it will instead ask the user to upgrade PROS instead. When the schema is shorter the behavior is still the same.
