### PR TITLE
🐛 Add sentry_sdk.integrations modules to explicit package deps for cx_freeze

### DIFF
--- a/build.py
+++ b/build.py
@@ -8,8 +8,18 @@ from install_requires import install_requires as install_reqs
 
 import pros.cli.main
 
+sentry_integrations = [
+    'django', 'spark', 'aiohttp', 'argv', 'asgi', 'atexit', 'aws_lambda', 'beam',
+    'boto3', 'bottle', 'celery', 'chalice', 'dedupe', 'excepthook', 'executing',
+    'falcon', 'flask', 'gcp', 'gnu_backtrace', 'logging', 'modules', 'pure_eval',
+    'pyramid', 'redis', 'rq', 'sanic', 'serverless', 'sqlalchemy', 'stdlib',
+    'threading', 'tornado', 'trytond', 'wsgi'
+]
+
 build_exe_options = {
-    'packages': ['ssl', 'requests', 'idna'] + [f'pros.cli.{root_source}' for root_source in pros.cli.main.root_sources],
+    'packages': ['ssl', 'requests', 'idna'] +
+        [f'sentry_sdk.integrations.{integration}' for integration in sentry_integrations] +
+        [f'pros.cli.{root_source}' for root_source in pros.cli.main.root_sources],
     "include_files": [(requests.certs.where(), 'cacert.pem')],
     'excludes': ['pip', 'distutils'],  # optimization excludes
     'constants': [


### PR DESCRIPTION
#### Summary:
<!-- Provide a concise description of your changes -->
Explicitly add all the modules from sentry_sdk.integrations to the list of packages given to cx_Freeze when building for windows.

#### Motivation:
<!-- Provide a brief description of why you think these changes need to be made -->
For whatever reason, cx_Freeze is unable to pick up on these dependencies within sentry_sdk, causing issues when users run the frozen distribution packaged with our windows install.

##### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->
related to https://github.com/pyinstaller/pyinstaller/issues/4755, except it's cx_Freeze and not PyInstaller

#### Test Plan:
<!-- Provide a list of steps that can be taken to verify these changes work as intended -->
- [x] run basic PROS operations using the frozen distribution for windows (verified in the 3.2.0.1 hotfix installers I built and we now distribute)
