### PR TITLE
🚸 Changed IDEs in Warning Message

### DIFF
--- a/pros/serial/ports/exceptions.py
+++ b/pros/serial/ports/exceptions.py
@@ -10,6 +10,6 @@ class ConnectionRefusedException(IOError):
         extra = ''
         if os.name == 'posix':
             extra = 'adding yourself to dialout group '
-        return f"could not open port '{self.port_name}'. Try closing any other VEX IDEs such as VEXCode, RobotMesh Studios, or " \
+        return f"could not open port '{self.port_name}'. Try closing any other VEX IDEs such as VEXCode, Robot Mesh Studio, or " \
             f"firmware utilities; moving to a different USB port; {extra}or " \
             f"restarting the device."

--- a/pros/serial/ports/exceptions.py
+++ b/pros/serial/ports/exceptions.py
@@ -10,6 +10,6 @@ class ConnectionRefusedException(IOError):
         extra = ''
         if os.name == 'posix':
             extra = 'adding yourself to dialout group '
-        return f"could not open port '{self.port_name}'. Try closing any other VEX IDEs such as ROBOTC, VCS, or " \
+        return f"could not open port '{self.port_name}'. Try closing any other VEX IDEs such as VEXCode, RobotMesh Studios, or " \
             f"firmware utilities; moving to a different USB port; {extra}or " \
             f"restarting the device."


### PR DESCRIPTION
#### Summary:
Given that the error for having another IDE open blocking the usb port to the brain still lists RobotC and VCS, I changed these to be more relevant to IDEs used today.
