### PR TITLE
Fix VSC Error

### DIFF
--- a/pros/cli/build.py
+++ b/pros/cli/build.py
@@ -22,7 +22,7 @@ def make(project: c.Project, build_args):
     """
     exit_code = project.compile(build_args)
     if exit_code != 0:
-        logger(__name__).debug(f'Failed to make project: Exit Code {exit_code}')
+        logger(__name__).error(f'Failed to make project: Exit Code {exit_code}', extra={'sentry': False})
         raise click.ClickException('Failed to build')
     return exit_code
 
@@ -66,6 +66,6 @@ def build_compile_commands(project: c.Project, suppress_output: bool, compile_co
     exit_code = project.make_scan_build(build_args, cdb_file=compile_commands, suppress_output=suppress_output,
                                         sandbox=sandbox)
     if exit_code != 0:
-        logger(__name__).debug(f'Failed to make project: Exit Code {exit_code}')
+        logger(__name__).error(f'Failed to make project: Exit Code {exit_code}', extra={'sentry': False})
         raise click.ClickException('Failed to build')
     return exit_code


### PR DESCRIPTION
Will allow build errors to appear as error notifications in the VSC extension. This will also result in there being two errors output to the terminal.