### PR TITLE
 ✨Improve message when creating in existing project

### DIFF
--- a/pros/cli/conductor.py
+++ b/pros/cli/conductor.py
@@ -203,7 +203,8 @@ def new_project(ctx: click.Context, path: str, target: str, version: str,
     if version.lower() == 'latest' or not version:
         version = '>0'
     if not force_system and c.Project.find_project(path) is not None:
-        logger(__name__).error('A project already exists in this location! Delete it first', extra={'sentry': False})
+        logger(__name__).error('A project already exists in this location at ' + c.Project.find_project(path) + 
+                               '! Delete it first. Are you creating a project in an existing one?', extra={'sentry': False})
         ctx.exit(-1)
     try:
         _conductor = c.Conductor()


### PR DESCRIPTION
#### Summary:
Improves error message when attempting to create a project in an existing one. Improves from previous file change by telling the user the path where the existing project is located.

#### Motivation:
Better error message makes it less confusing for the user.

##### References (optional):
#44 
This pull request may be redundant to this other one, but the other one is stale https://github.com/purduesigbots/pros-cli/pull/51

#### Test Plan:
Create an empty folder, then make a new project in it. Then, attempt to make a new project again in the same folder.
![image](https://user-images.githubusercontent.com/57331513/137407867-9e2fbce4-2553-45b5-9066-5b09741d6137.png)
