### PR TITLE
🐛Fixes --run-after flag priority issues.

### DIFF
--- a/pros/cli/click_classes.py
+++ b/pros/cli/click_classes.py
@@ -78,6 +78,20 @@ class PROSOption(click.Option):
             return
         return super().get_help_record(ctx)
 
+class PROSDeprecated(PROSOption):
+    def __init__(self, *args, hidden: bool = False, group: str = None, replacement: str = None, **kwargs):
+        super(PROSDeprecated, self).__init__(*args, hidden, group, **kwargs)
+        self.optiontype="flag" if str(self.type)=="BOOL" else "switch"
+        self.to_use = replacement
+        self.arg = args[0][len(args[0])-1]
+        self.msg="The '--{}' {} has been deprecated. Please use '--{}' instead."
+        if replacement==None:
+            self.msg = self.msg.split(".")[0]+"."
+
+    def type_cast_value(self, ctx, value):
+        if not value==self.default:
+            print("Warning! : "+self.msg.format(self.arg,self.optiontype,self.to_use)+"\n")
+        return value
 
 class PROSGroup(PROSFormatted, click.Group):
     def __init__(self, *args, **kwargs):

--- a/pros/cli/click_classes.py
+++ b/pros/cli/click_classes.py
@@ -78,19 +78,23 @@ class PROSOption(click.Option):
             return
         return super().get_help_record(ctx)
 
-class PROSDeprecated(PROSOption):
-    def __init__(self, *args, hidden: bool = False, group: str = None, replacement: str = None, **kwargs):
-        super(PROSDeprecated, self).__init__(*args, hidden, group, **kwargs)
-        self.optiontype="flag" if str(self.type)=="BOOL" else "switch"
+class PROSDeprecated(click.Option):
+    def __init__(self, *args, replacement: str = None, **kwargs):
+        kwargs['help'] = "This option has been deprecated."
+        if not replacement==None:
+            kwargs['help'] += " Its replacement is '--{}'".format(replacement)
+        super(PROSDeprecated, self).__init__(*args, **kwargs)
+        self.group = "Deprecated"
+        self.optiontype = "flag" if str(self.type)=="BOOL" else "switch"
         self.to_use = replacement
         self.arg = args[0][len(args[0])-1]
-        self.msg="The '--{}' {} has been deprecated. Please use '--{}' instead."
+        self.msg = "The '{}' {} has been deprecated. Please use '--{}' instead."
         if replacement==None:
             self.msg = self.msg.split(".")[0]+"."
 
     def type_cast_value(self, ctx, value):
         if not value==self.default:
-            print("Warning! : "+self.msg.format(self.arg,self.optiontype,self.to_use)+"\n")
+            print("Warning! : "+self.msg.format(self.arg, self.optiontype, self.to_use)+"\n")
         return value
 
 class PROSGroup(PROSFormatted, click.Group):

--- a/pros/cli/upload.py
+++ b/pros/cli/upload.py
@@ -12,25 +12,29 @@ def upload_cli():
 
 
 @upload_cli.command(aliases=['u'])
-@click.option('--target', '-t', type=click.Choice(['v5', 'cortex']), default=None, required=False,
+@click.option('--target', type=click.Choice(['v5', 'cortex']), default=None, required=False,
               help='Specify the target microcontroller. Overridden when a PROS project is specified.')
 @click.argument('path', type=click.Path(exists=True), default=None, required=False)
 @click.argument('port', type=str, default=None, required=False)
 @project_option(required=False, allow_none=True)
-@click.option('-r/-nr', '--run-after/--no-run-after', 'run_after', default=False, help='Immediately run the uploaded program.')
-@click.option('-rs/-nrs', '--run-screen/--no-run-screen', 'run_screen', default=True, help='Display run program screen on the brain after upload.')
-@click.option('-q', '--quirk', type=int, default=0)
-@click.option('-n', '--name', 'remote_name', type=str, default=None, required=False, help='Remote program name.',
+@click.option('-ra/-nr', '--run-after/--no-run-after', 'run_after', default=None, help='Immediately run the uploaded program.',
+              cls=PROSDeprecated, replacement='after')
+@click.option('-rs/-ex', '--run-screen/--execute', 'run_screen', default=None, help='Display run program screen on the brain after upload.',
+              cls=PROSDeprecated, replacement='after')
+@click.option('-af', '--after', type=click.Choice(['run','screen','none']), default=None, help='Action to perform on the brain after upload.', 
               cls=PROSOption, group='V5 Options')
-@click.option('-s', '--slot', default=None, type=click.IntRange(min=1, max=8), help='Program slot on the GUI.',
+@click.option('--quirk', type=int, default=0)
+@click.option('--name', 'remote_name', type=str, default=None, required=False, help='Remote program name.',
               cls=PROSOption, group='V5 Options')
-@click.option('-pv', '--program-version', default=None, type=str, help='Specify version metadata for program.',
+@click.option('--slot', default=None, type=click.IntRange(min=1, max=8), help='Program slot on the GUI.',
+              cls=PROSOption, group='V5 Options')
+@click.option('--program-version', default=None, type=str, help='Specify version metadata for program.',
               cls=PROSOption, group='V5 Options', hidden=True)
 @click.option('--icon', default=None, type=str,
               cls=PROSOption, group='V5 Options', hidden=True)
-@click.option('-i', '--ini-config', type=click.Path(exists=True), default=None, help='Specify a program configuration file.',
+@click.option('--ini-config', type=click.Path(exists=True), default=None, help='Specify a program configuration file.',
               cls=PROSOption, group='V5 Options', hidden=True)
-@click.option('-cb/-ncb', '--compress-bin/--no-compress-bin', 'compress_bin', cls=PROSOption, group='V5 Options', default=True,
+@click.option('--compress-bin/--no-compress-bin', 'compress_bin', cls=PROSOption, group='V5 Options', default=True,
               help='Compress the program binary before uploading.')
 @default_options
 def upload(path: Optional[str], project: Optional[c.Project], port: str, **kwargs):
@@ -89,18 +93,27 @@ def upload(path: Optional[str], project: Optional[c.Project], port: str, **kwarg
             kwargs['remote_name'] = os.path.splitext(os.path.basename(path))[0]
         kwargs['remote_name'] = kwargs['remote_name'].replace('@', '_')
         kwargs['slot'] -= 1
-        if kwargs['run_after']:
-            kwargs['run_after'] = vex.V5Device.FTCompleteOptions.RUN_IMMEDIATELY
-        elif kwargs['run_screen']:
-            kwargs['run_after'] = vex.V5Device.FTCompleteOptions.RUN_SCREEN
-        else:
-            kwargs['run_after'] = vex.V5Device.FTCompleteOptions.DONT_RUN
+        
+        action_to_kwarg = {
+            'run' : vex.V5Device.FTCompleteOptions.RUN_IMMEDIATELY, 
+            'screen' : vex.V5Device.FTCompleteOptions.RUN_SCREEN, 
+            'none' : vex.V5Device.FTCompleteOptions.DONT_RUN
+            }    
+        after_upload_default = 'screen'
+        #Determine which FTCompleteOption to assign to run_after
+        if kwargs['after']==None:
+            kwargs['after']=after_upload_default
+            if kwargs['run_after']:
+                kwargs['after']='run'
+            elif kwargs['run_screen']==False and not kwargs['run_after']:
+                kwargs['after']='none'
+        kwargs['run_after'] = action_to_kwarg[kwargs['after']]
         kwargs.pop('run_screen')
+        kwargs.pop('after')
     elif kwargs['target'] == 'cortex':
         pass
 
     logger(__name__).debug('Arguments: {}'.format(str(kwargs)))
-
     # Do the actual uploading!
     try:
         ser = DirectPort(port)
@@ -117,7 +130,6 @@ def upload(path: Optional[str], project: Optional[c.Project], port: str, **kwarg
     except Exception as e:
         logger(__name__).exception(e, exc_info=True)
         exit(1)
-
 
 @upload_cli.command('lsusb', aliases=['ls-usb', 'ls-devices', 'lsdev', 'list-usb', 'list-devices'])
 @click.option('--target', type=click.Choice(['v5', 'cortex']), default=None, required=False)

--- a/pros/cli/upload.py
+++ b/pros/cli/upload.py
@@ -12,26 +12,26 @@ def upload_cli():
 
 
 @upload_cli.command(aliases=['u'])
-@click.option('--target', type=click.Choice(['v5', 'cortex']), default=None, required=False,
+@click.option('--target', '-t', type=click.Choice(['v5', 'cortex']), default=None, required=False,
               help='Specify the target microcontroller. Overridden when a PROS project is specified.')
 @click.argument('path', type=click.Path(exists=True), default=None, required=False)
 @click.argument('port', type=str, default=None, required=False)
 @project_option(required=False, allow_none=True)
-@click.option('--run-after/--no-run-after', 'run_after', default=False, help='Immediately run the uploaded program')
+@click.option('-r/-nr', '--run-after/--no-run-after', 'run_after', default=False, help='Immediately run the uploaded program.')
+@click.option('-rs/-nrs', '--run-screen/--no-run-screen', 'run_screen', default=True, help='Display run program screen on the brain after upload.')
 @click.option('-q', '--quirk', type=int, default=0)
-@click.option('--name', 'remote_name', type=str, default=None, required=False, help='Remote program name',
+@click.option('-n', '--name', 'remote_name', type=str, default=None, required=False, help='Remote program name.',
               cls=PROSOption, group='V5 Options')
-@click.option('--slot', default=None, type=click.IntRange(min=1, max=8), help='Program slot on the GUI',
+@click.option('-s', '--slot', default=None, type=click.IntRange(min=1, max=8), help='Program slot on the GUI.',
               cls=PROSOption, group='V5 Options')
-@click.option('--program-version', default=None, type=str, help='Specify version metadata for program',
+@click.option('-pv', '--program-version', default=None, type=str, help='Specify version metadata for program.',
               cls=PROSOption, group='V5 Options', hidden=True)
 @click.option('--icon', default=None, type=str,
               cls=PROSOption, group='V5 Options', hidden=True)
-@click.option('--ini-config', type=click.Path(exists=True), default=None, help='Specify a Program Configuration File',
+@click.option('-i', '--ini-config', type=click.Path(exists=True), default=None, help='Specify a program configuration file.',
               cls=PROSOption, group='V5 Options', hidden=True)
-@click.option('--compress-bin/--no-compress-bin', 'compress_bin', cls=PROSOption, group='V5 Options', default=True,
+@click.option('-cb/-ncb', '--compress-bin/--no-compress-bin', 'compress_bin', cls=PROSOption, group='V5 Options', default=True,
               help='Compress the program binary before uploading.')
-@click.option('--run-screen/--no-run-screen', 'run_screen', default=True, help='Display run program screen on brain after upload.')
 @default_options
 def upload(path: Optional[str], project: Optional[c.Project], port: str, **kwargs):
     """
@@ -59,9 +59,8 @@ def upload(path: Optional[str], project: Optional[c.Project], port: str, **kwarg
         options = dict(**project.upload_options)
         if 'slot' in options and kwargs.get('slot', None) is None:
             kwargs.pop('slot')
-        elif kwargs.get('slot', None) is None: 
+        elif kwargs.get('slot', None) is None:
             kwargs['slot'] = 1
-            
         options.update(kwargs)
         kwargs = options
 

--- a/pros/cli/upload.py
+++ b/pros/cli/upload.py
@@ -17,9 +17,9 @@ def upload_cli():
 @click.argument('path', type=click.Path(exists=True), default=None, required=False)
 @click.argument('port', type=str, default=None, required=False)
 @project_option(required=False, allow_none=True)
-@click.option('-ra/-nr', '--run-after/--no-run-after', 'run_after', default=None, help='Immediately run the uploaded program.',
+@click.option('--run-after/--no-run-after', 'run_after', default=None, help='Immediately run the uploaded program.',
               cls=PROSDeprecated, replacement='after')
-@click.option('-rs/-ex', '--run-screen/--execute', 'run_screen', default=None, help='Display run program screen on the brain after upload.',
+@click.option('--run-screen/--execute', 'run_screen', default=None, help='Display run program screen on the brain after upload.',
               cls=PROSDeprecated, replacement='after')
 @click.option('-af', '--after', type=click.Choice(['run','screen','none']), default=None, help='Action to perform on the brain after upload.', 
               cls=PROSOption, group='V5 Options')

--- a/pros/cli/upload.py
+++ b/pros/cli/upload.py
@@ -17,7 +17,7 @@ def upload_cli():
 @click.argument('path', type=click.Path(exists=True), default=None, required=False)
 @click.argument('port', type=str, default=None, required=False)
 @project_option(required=False, allow_none=True)
-@click.option('--no-run-after/--run-after', 'run_after', default=False, help='Immediately run the uploaded program')
+@click.option('--run-after/--no-run-after', 'run_after', default=False, help='Immediately run the uploaded program')
 @click.option('-q', '--quirk', type=int, default=0)
 @click.option('--name', 'remote_name', type=str, default=None, required=False, help='Remote program name',
               cls=PROSOption, group='V5 Options')
@@ -93,7 +93,7 @@ def upload(path: Optional[str], project: Optional[c.Project], port: str, **kwarg
         if kwargs['run_after']:
             kwargs['run_after'] = vex.V5Device.FTCompleteOptions.RUN_IMMEDIATELY
         elif kwargs['run_screen']:
-            kwargs['run_after'] = vex.v5Device.FTCompleteOptions.RUN_SCREEN
+            kwargs['run_after'] = vex.V5Device.FTCompleteOptions.RUN_SCREEN
         else:
             kwargs['run_after'] = vex.V5Device.FTCompleteOptions.DONT_RUN
         kwargs.pop('run_screen')

--- a/pros/cli/upload.py
+++ b/pros/cli/upload.py
@@ -31,6 +31,7 @@ def upload_cli():
               cls=PROSOption, group='V5 Options', hidden=True)
 @click.option('--compress-bin/--no-compress-bin', 'compress_bin', cls=PROSOption, group='V5 Options', default=True,
               help='Compress the program binary before uploading.')
+@click.option('--run-screen/--no-run-screen', 'run_screen', default=True, help='Display run program screen on brain after upload.')
 @default_options
 def upload(path: Optional[str], project: Optional[c.Project], port: str, **kwargs):
     """
@@ -91,8 +92,11 @@ def upload(path: Optional[str], project: Optional[c.Project], port: str, **kwarg
         kwargs['slot'] -= 1
         if kwargs['run_after']:
             kwargs['run_after'] = vex.V5Device.FTCompleteOptions.RUN_IMMEDIATELY
+        elif kwargs['run_screen']:
+            kwargs['run_after'] = vex.v5Device.FTCompleteOptions.RUN_SCREEN
         else:
-            kwargs['run_after'] = vex.V5Device.FTCompleteOptions.RUN_SCREEN
+            kwargs['run_after'] = vex.V5Device.FTCompleteOptions.DONT_RUN
+        kwargs.pop('run_screen')
     elif kwargs['target'] == 'cortex':
         pass
 

--- a/pros/cli/upload.py
+++ b/pros/cli/upload.py
@@ -17,7 +17,7 @@ def upload_cli():
 @click.argument('path', type=click.Path(exists=True), default=None, required=False)
 @click.argument('port', type=str, default=None, required=False)
 @project_option(required=False, allow_none=True)
-@click.option('--run-after/--no-run-after', 'run_after', default=True, help='Immediately run the uploaded program')
+@click.option('--no-run-after/--run-after', 'run_after', default=False, help='Immediately run the uploaded program')
 @click.option('-q', '--quirk', type=int, default=0)
 @click.option('--name', 'remote_name', type=str, default=None, required=False, help='Remote program name',
               cls=PROSOption, group='V5 Options')
@@ -29,10 +29,6 @@ def upload_cli():
               cls=PROSOption, group='V5 Options', hidden=True)
 @click.option('--ini-config', type=click.Path(exists=True), default=None, help='Specify a Program Configuration File',
               cls=PROSOption, group='V5 Options', hidden=True)
-@click.option('--run-screen/--execute', 'run_screen', default=True,
-              cls=PROSOption, group='V5 Options', help='Open "run program" screen after uploading, instead of executing'
-                                                       ' program. This option may help with controller connectivity '
-                                                       'reliability and prevent robots from running off tables.')
 @click.option('--compress-bin/--no-compress-bin', 'compress_bin', cls=PROSOption, group='V5 Options', default=True,
               help='Compress the program binary before uploading.')
 @default_options
@@ -93,13 +89,10 @@ def upload(path: Optional[str], project: Optional[c.Project], port: str, **kwarg
             kwargs['remote_name'] = os.path.splitext(os.path.basename(path))[0]
         kwargs['remote_name'] = kwargs['remote_name'].replace('@', '_')
         kwargs['slot'] -= 1
-        if kwargs['run_after'] and kwargs['run_screen']:
-            kwargs['run_after'] = vex.V5Device.FTCompleteOptions.RUN_SCREEN
-        elif kwargs['run_after'] and not kwargs['run_screen']:
+        if kwargs['run_after']:
             kwargs['run_after'] = vex.V5Device.FTCompleteOptions.RUN_IMMEDIATELY
         else:
-            kwargs['run_after'] = vex.V5Device.FTCompleteOptions.DONT_RUN
-        kwargs.pop('run_screen')
+            kwargs['run_after'] = vex.V5Device.FTCompleteOptions.RUN_SCREEN
     elif kwargs['target'] == 'cortex':
         pass
 


### PR DESCRIPTION
#### Summary:
Changes logic statements when deciding which vex.V5Device.FTCompleteOptions argument to pass. Essentially gives the --run-after switch priority over the --run-screen switch in the if/elif/else chain.

#### Motivation:
Quality of life feature for users that will allow them to make changes and test them more efficiently. Removes the need to go through the controller menu or press buttons on the brain to test changes.

##### References (optional):
closes #132 

#### Test Plan:
Tested every combination of --run-after and --run-screen switches to verify that new logic works.
The link to a video of the test cases is here: https://drive.google.com/file/d/1mYM6LzFtDHzZ1Jm6cl8S6FvG-k9EKSDa/view?usp=sharing