### PR TITLE
Fix outdated Ubuntu and Windows VM Image for CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ jobs:
       x86:
         buildArch: x86
   pool:
-    vmImage: vs2017-win2016
+    vmImage: windows-latest
   steps:
     - powershell: choco install 7zip.install -y
       displayName: Install 7z

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ jobs:
 - job: UpdateBuildNumber
   timeoutInMinutes: 5
   pool:
-    vmImage: ubuntu-18.04
+    vmImage: ubuntu-latest
 
   steps:
     - task: UsePythonVersion@0
@@ -53,7 +53,7 @@ jobs:
       # x86:
       #   buildArch: x86
   pool:
-    vmImage: ubuntu-18.04
+    vmImage: ubuntu-latest
   steps:
 #   Microsoft/azure-pipelines-image-generation#225
     # - bash: |


### PR DESCRIPTION
Change Ubuntu Image from `18.04` to `ubuntu-latest` and Windows image from `vs2017-win2016` to `windows-latest`