### PR TITLE
✨ Create macOS CI + Script Cleanup

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,5 @@
 variables:
-  python.version.linux: '3.7.x'
-  python.version.windows: '3.7.x'
+  python.version: '3.9.x'
 
 jobs:
 - job: UpdateBuildNumber
@@ -11,7 +10,7 @@ jobs:
   steps:
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: $(python.version.linux)
+        versionSpec: $(python.version)
         architecture: x64
     - script: python version.py
     - bash: echo "##vso[build.UpdateBuildNumber]`cat version`"
@@ -33,13 +32,35 @@ jobs:
       displayName: Install 7z
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: $(python.version.windows)
+        versionSpec: $(python.version)
         architecture: $(buildArch)
     - powershell: scripts/build.ps1
       displayName: Build
     - task: PublishPipelineArtifact@0
       inputs:
         artifactName: 'pros_cli-$(Build.BuildNumber)-win-$(buildArch)'
+        targetPath: 'out'
+
+- job: macOS
+  timeoutInMinutes: 30
+  dependsOn: UpdateBuildNumber
+  strategy:
+    maxParallel: 2
+    matrix:
+      x64:
+        buildArch: x64
+  pool:
+    vmImage: macos-latest
+  steps:
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: $(python.version)
+        architecture: $(buildArch)
+    - bash: scripts/build.sh
+      displayName: Build
+    - task: PublishPipelineArtifact@0
+      inputs:
+        artifactName: 'pros_cli-$(Build.BuildNumber)-macos-$(buildArch)'
         targetPath: 'out'
 
 - job: Linux
@@ -50,21 +71,12 @@ jobs:
     matrix:
       x64:
         buildArch: x64
-      # x86:
-      #   buildArch: x86
   pool:
     vmImage: ubuntu-latest
   steps:
-#   Microsoft/azure-pipelines-image-generation#225
-    # - bash: |
-    #     sudo apt-add-repository ppa:deadsnakes/ppa
-    #     sudo apt-get update
-    #     sudo apt-get install python3.6 python3.6-dev python3-setuptools
-    #   displayName: Use Python 3.6
-#     Hopefully this will work soon
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: $(python.version.linux)
+        versionSpec: $(python.version)
         architecture: $(buildArch)
     - bash: scripts/build.sh
       displayName: Build
@@ -81,7 +93,7 @@ jobs:
   steps:
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: $(python.version.linux)
+        versionSpec: $(python.version)
         architecture: x64
     - checkout: none
     - task: DownloadPipelineArtifact@2


### PR DESCRIPTION
Creates macOS CI to generate artifacts for macOS. Will be necessary for upcoming vscode one-click install feature. Some clean up to the script and updates to python version are also included. 