### PR TITLE
🚸 remove old rfc6266-parser package

### DIFF
--- a/pros/common/utils.py
+++ b/pros/common/utils.py
@@ -111,20 +111,22 @@ def download_file(url: str, ext: Optional[str] = None, desc: Optional[str] = Non
     """
     import requests
     from pros.common.ui import progressbar
-    from rfc6266_parser import parse_requests_response
+    # from rfc6266_parser import parse_requests_response
+    import re
 
     response = requests.get(url, stream=True)
     if response.status_code == 200:
         filename: str = url.rsplit('/', 1)[-1]
         if 'Content-Disposition' in response.headers.keys():
-            try:
-                disposition = parse_requests_response(response)
-                if isinstance(ext, str):
-                    filename = disposition.filename_sanitized(ext)
-                else:
-                    filename = disposition.filename_unsafe
-            except RuntimeError:
-                pass
+            filename = re.findall("filename=(.+)", response.headers['Content-Disposition'])[0]
+            # try:
+            #     disposition = parse_requests_response(response)
+            #     if isinstance(ext, str):
+            #         filename = disposition.filename_sanitized(ext)
+            #     else:
+            #         filename = disposition.filename_unsafe
+            # except RuntimeError:
+            #     pass
         output_path = os.path.join(get_pros_dir(), 'download', filename)
 
         if os.path.exists(output_path):

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ colorama
 pyzmq
 cobs
 scan-build==2.0.13
-rfc6266-parser
 sentry-sdk
 observable
 pypng==0.0.20


### PR DESCRIPTION
#### Summary:
<!-- Provide a concise description of your changes -->
remove uses of the rfc6266-parser package

#### Motivation:
<!-- Provide a brief description of why you think these changes need to be made -->
it's been left without update since 2017, and [a recent version of setuptools](https://setuptools.pypa.io/en/latest/history.html#id58) has broken one of its dependencies.

##### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->

#### Test Plan:
<!-- Provide a list of steps that can be taken to verify these changes work as intended -->

- [x] download kernel/okapilib templates properly
