### PR TITLE
🐛 emit correct compiler for C files when generating CDB

### DIFF
--- a/pros/conductor/project/__init__.py
+++ b/pros/conductor/project/__init__.py
@@ -385,7 +385,7 @@ class Project(Config):
 
         def entry_map(entry: Compilation):
             json_entry = entry.as_db_entry()
-            json_entry['arguments'][0] = 'clang' if entry.compiler == 'cc' else 'clang++'
+            json_entry['arguments'][0] = 'clang' if entry.compiler == 'c' else 'clang++'
             return json_entry
 
         entries = itertools.chain(old_entries, new_entries)


### PR DESCRIPTION
#### Summary:
<!-- Provide a concise description of your changes -->
This change fixes a bug where compilation database entries all had clang++ specified as the compiler, even if the entry was for a C file.

#### Motivation:
<!-- Provide a brief description of why you think these changes need to be made -->
As a result of the bug, the clangd language server erroneously reported that `--std=gnu11` was an invalid flag for C++ files at the top of every C file.

##### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->
N/A

#### Test Plan:
<!-- Provide a list of steps that can be taken to verify these changes work as intended -->

- [X] CDB is generated with clang entries for C files and clang++ entries for C++ files
- [X] clangd no longer reports an error for C files
