### PR TITLE
Update Azure Pipelines with new self hosted M1 Mac

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,10 +74,10 @@ jobs:
   pool:
     M1 Mac
   steps:
-    # - task: UsePythonVersion@0
-    #   inputs:
-    #     versionSpec: $(python.version)
-    #     architecture: $(buildArch)
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: $(python.version)
+        architecture: $(buildArch)
     - bash: scripts/build.sh
       displayName: Build
     - task: PublishPipelineArtifact@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,6 +63,28 @@ jobs:
         artifactName: 'pros_cli-$(Build.BuildNumber)-macos-$(buildArch)'
         targetPath: 'out'
 
+- job: macOS M1
+  timeoutInMinutes: 30
+  dependsOn: UpdateBuildNumber
+  strategy:
+    maxParallel: 2
+    matrix:
+      x64:
+        buildArch: x64
+  pool:
+    M1 Mac
+  steps:
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: $(python.version)
+        architecture: $(buildArch)
+    - bash: scripts/build.sh
+      displayName: Build
+    - task: PublishPipelineArtifact@0
+      inputs:
+        artifactName: 'pros_cli-$(Build.BuildNumber)-macos-$(buildArch)'
+        targetPath: 'out'
+
 - job: Linux
   timeoutInMinutes: 30
   dependsOn: UpdateBuildNumber

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 variables:
-  python.version: '3.9.x'
+  python.version: '3.8.x'
 
 jobs:
 - job: UpdateBuildNumber

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,10 +74,10 @@ jobs:
   pool:
     M1 Mac
   steps:
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: $(python.version)
-        architecture: $(buildArch)
+    # - task: UsePythonVersion@0
+    #   inputs:
+    #     versionSpec: $(python.version)
+    #     architecture: $(buildArch)
     - bash: scripts/build.sh
       displayName: Build
     - task: PublishPipelineArtifact@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,7 +63,7 @@ jobs:
         artifactName: 'pros_cli-$(Build.BuildNumber)-macos-$(buildArch)'
         targetPath: 'out'
 
-- job: macOS M1
+- job: macOSM1
   timeoutInMinutes: 30
   dependsOn: UpdateBuildNumber
   strategy:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,8 +69,8 @@ jobs:
   strategy:
     maxParallel: 2
     matrix:
-      x64:
-        buildArch: x64
+      amd64:
+        buildArch: arm64
   pool:
     M1 Mac
   steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,7 +69,7 @@ jobs:
   strategy:
     maxParallel: 2
     matrix:
-      amd64:
+      arm64:
         buildArch: arm64
   pool:
     M1 Mac

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 variables:
-  python.version: '3.8.x'
+  python.version: '3.9.x'
 
 jobs:
 - job: UpdateBuildNumber


### PR DESCRIPTION
Will allow for M1 Mac Builds, needed for upcoming vscode one-click feature.