### PR TITLE
Fixes 'make.exe.exe' typo. Adds disable sentry prompt option for VSCode.

### DIFF
--- a/pros/cli/main.py
+++ b/pros/cli/main.py
@@ -65,13 +65,12 @@ def version(ctx: click.Context, param, value):
 @click.command('pros',
                cls=PROSCommandCollection,
                sources=root_commands)
-@click.option('--sentry-off', help='Disables sentry reporting prompt (Made for VSCode Extension)', is_flag=True, default=False)
 @default_options
 @click.option('--version', help='Displays version and exits', is_flag=True, expose_value=False, is_eager=True,
               callback=version)
+@click.option('--sentry-off', help='Disables sentry reporting prompt (Made for VSCode Extension)',is_flag=True,default=False)
 def cli(**kwargs):
-    pros.common.sentry.register(kwargs['sentry-off'])
-
+    pros.common.sentry.register(kwargs['sentry_off'])
 
 if __name__ == '__main__':
     main()

--- a/pros/cli/main.py
+++ b/pros/cli/main.py
@@ -65,11 +65,12 @@ def version(ctx: click.Context, param, value):
 @click.command('pros',
                cls=PROSCommandCollection,
                sources=root_commands)
+@click.option('--sentry-off', help='Disables sentry reporting prompt (Made for VSCode Extension)', is_flag=True, default=False)
 @default_options
 @click.option('--version', help='Displays version and exits', is_flag=True, expose_value=False, is_eager=True,
               callback=version)
-def cli():
-    pros.common.sentry.register()
+def cli(**kwargs):
+    pros.common.sentry.register(kwargs['sentry-off'])
 
 
 if __name__ == '__main__':

--- a/pros/cli/main.py
+++ b/pros/cli/main.py
@@ -68,9 +68,9 @@ def version(ctx: click.Context, param, value):
 @default_options
 @click.option('--version', help='Displays version and exits', is_flag=True, expose_value=False, is_eager=True,
               callback=version)
-@click.option('--sentry-off', help='Disables sentry reporting prompt (Made for VSCode Extension)',is_flag=True,default=False)
+@click.option('--no-sentry', help='Disables sentry reporting prompt (Made for VSCode Extension)',is_flag=True,default=False)
 def cli(**kwargs):
-    pros.common.sentry.register(kwargs['sentry_off'])
+    pros.common.sentry.register(kwargs['no_sentry'])
 
 if __name__ == '__main__':
     main()

--- a/pros/common/sentry.py
+++ b/pros/common/sentry.py
@@ -109,7 +109,7 @@ def add_tag(key: str, value: str):
         scope.set_tag(key, value)
 
 
-def register(force_off: True, cfg: Optional['CliConfig'] = None):
+def register(force_off, cfg: Optional['CliConfig'] = None):
     global cli_config, client, force_prompt_off
     force_prompt_off = force_off
     if cfg is None:

--- a/pros/conductor/project/__init__.py
+++ b/pros/conductor/project/__init__.py
@@ -233,7 +233,7 @@ class Project(Config):
         except Exception as e:
             if not os.environ.get('PROS_TOOLCHAIN'):
                 ui.logger(__name__).warn("PROS toolchain not found! Please ensure the toolchain is installed correctly and your environment variables are set properly.\n")
-            ui.logger(__name__).error(f"ERROR WHILE CALLING '{make_cmd}.exe' WITH EXCEPTION: {str(e)}\n")
+            ui.logger(__name__).error(f"ERROR WHILE CALLING '{make_cmd}' WITH EXCEPTION: {str(e)}\n",extra={'sentry':False})
             stdout_pipe.close()
             stderr_pipe.close()
             sys.exit()
@@ -290,7 +290,7 @@ class Project(Config):
                 except Exception as e:
                     if not os.environ.get('PROS_TOOLCHAIN'):
                         ui.logger(__name__).warn("PROS toolchain not found! Please ensure the toolchain is installed correctly and your environment variables are set properly.\n")
-                    ui.logger(__name__).error(f"ERROR WHILE CALLING '{make_cmd}.exe' WITH EXCEPTION: {str(e)}\n")
+                    ui.logger(__name__).error(f"ERROR WHILE CALLING '{make_cmd}' WITH EXCEPTION: {str(e)}\n",extra={'sentry':False})
                     if not suppress_output: 
                         pipe.close()
                     sys.exit()


### PR DESCRIPTION
#### Summary:
Fixes typo that was causing toolchain missing errors in VSCode to appear as "ERROR WHILE CALLING make.exe.exe WITH EXCEPTION" instead of "ERROR WHILE CALLING make.exe WITH EXCEPTION".

Adds `--sentry-off` flag to disable the sentry error reporting y/N prompt.

#### Motivation:
These two CLI changes need to be made before the one-click feature releases.

#### Test Plan:
- [ ] Run pros make with VSCode extension to make sure it says "make.exe" instead of "make.exe.exe" in VSCode.
Haven't been able to test this but I removed the extra ".exe" string that was causing this issue.
- [x] Call a logger error/exception with and without the `--sentry-off` flag.
![image](https://user-images.githubusercontent.com/48661356/148853619-ffdecd6e-20bd-4e5b-98a2-2314b35764fa.png)
![image](https://user-images.githubusercontent.com/48661356/148853763-6c2eea0f-2be2-4dbc-b7d4-b91c575329f0.png)
