### PR TITLE
✨More Upload Options

### DIFF
--- a/pros/cli/upload.py
+++ b/pros/cli/upload.py
@@ -55,7 +55,7 @@ def upload(path: Optional[str], project: Optional[c.Project], port: str, **kwarg
     """
     import pros.serial.devices.vex as vex
     from pros.serial.ports import DirectPort
-    kwargs['ide_version'] = project.kernel
+    kwargs['ide_version'] = project.kernel if not project==None else "None"
     kwargs['ide'] = 'PROS'
     name_to_file = {
         'pros' : 'USER902x.bmp',
@@ -109,10 +109,8 @@ def upload(path: Optional[str], project: Optional[c.Project], port: str, **kwarg
         raise dont_send(click.UsageError('No port provided or located. Make sure to specify --target if needed.'))
     if kwargs['target'] == 'v5':
         kwargs['remote_name'] = kwargs['name'] if kwargs.get("name",None) else kwargs['remote_name']
-        print(kwargs['remote_name'])
         if kwargs['remote_name'] is None:
             kwargs['remote_name'] = os.path.splitext(os.path.basename(path))[0]
-        print(kwargs['remote_name'])
         kwargs['remote_name'] = kwargs['remote_name'].replace('@', '_')
         kwargs['slot'] -= 1
         

--- a/pros/cli/upload.py
+++ b/pros/cli/upload.py
@@ -1,4 +1,5 @@
 from sys import exit
+from unicodedata import name
 
 import pros.common.ui as ui
 import pros.conductor as c
@@ -28,14 +29,19 @@ def upload_cli():
               cls=PROSOption, group='V5 Options')
 @click.option('--slot', default=None, type=click.IntRange(min=1, max=8), help='Program slot on the GUI.',
               cls=PROSOption, group='V5 Options')
+@click.option('--icon', type=click.Choice(['pros','pizza','planet','alien','ufo','robot']), default='pros',
+              help="Change Program's icon on the V5 Brain", cls=PROSOption, group='V5 Options')
 @click.option('--program-version', default=None, type=str, help='Specify version metadata for program.',
-              cls=PROSOption, group='V5 Options', hidden=True)
-@click.option('--icon', default=None, type=str,
               cls=PROSOption, group='V5 Options', hidden=True)
 @click.option('--ini-config', type=click.Path(exists=True), default=None, help='Specify a program configuration file.',
               cls=PROSOption, group='V5 Options', hidden=True)
 @click.option('--compress-bin/--no-compress-bin', 'compress_bin', cls=PROSOption, group='V5 Options', default=True,
               help='Compress the program binary before uploading.')
+@click.option('--description', default=None, type=str, cls=PROSOption, group='V5 Options', 
+              help='Change the description displayed for the program.')
+@click.option('--name', default=None, type=str, cls=PROSOption, group='V5 Options', 
+              help='Change the name of the program.')
+
 @default_options
 def upload(path: Optional[str], project: Optional[c.Project], port: str, **kwargs):
     """
@@ -49,6 +55,17 @@ def upload(path: Optional[str], project: Optional[c.Project], port: str, **kwarg
     """
     import pros.serial.devices.vex as vex
     from pros.serial.ports import DirectPort
+    kwargs['ide_version'] = project.kernel
+    kwargs['ide'] = 'PROS'
+    name_to_file = {
+        'pros' : 'USER902x',
+        'pizza' : 'USER003x',
+        'planet' : 'USER013x',
+        'alien' : 'USER027x',
+        'ufo' : 'USER029x',
+        'robot' : 'USER010x'
+    }
+    kwargs['icon'] = name_to_file[kwargs['icon']]
     if path is None or os.path.isdir(path):
         if project is None:
             project_path = c.Project.find_project(path or os.getcwd())
@@ -77,7 +94,6 @@ def upload(path: Optional[str], project: Optional[c.Project], port: str, **kwarg
     if 'target' not in kwargs or kwargs['target'] is None:
         logger(__name__).debug(f'Target not specified. Arguments provided: {kwargs}')
         raise click.UsageError('Target not specified. specify a project (using the file argument) or target manually')
-
     if kwargs['target'] == 'v5':
         port = resolve_v5_port(port, 'system')[0]
     elif kwargs['target'] == 'cortex':
@@ -87,7 +103,6 @@ def upload(path: Optional[str], project: Optional[c.Project], port: str, **kwarg
         logger(__name__).debug('Target should be one of ("v5" or "cortex").')
     if not port:
         raise dont_send(click.UsageError('No port provided or located. Make sure to specify --target if needed.'))
-
     if kwargs['target'] == 'v5':
         if kwargs['remote_name'] is None:
             kwargs['remote_name'] = os.path.splitext(os.path.basename(path))[0]

--- a/pros/cli/upload.py
+++ b/pros/cli/upload.py
@@ -29,7 +29,7 @@ def upload_cli():
               cls=PROSOption, group='V5 Options')
 @click.option('--slot', default=None, type=click.IntRange(min=1, max=8), help='Program slot on the GUI.',
               cls=PROSOption, group='V5 Options')
-@click.option('--icon', type=click.Choice(['pros','pizza','planet','alien','ufo','robot']), default='pros',
+@click.option('--icon', type=click.Choice(['pros','pizza','planet','alien','ufo','robot','clawbot','question','X','power']), default='pros',
               help="Change Program's icon on the V5 Brain", cls=PROSOption, group='V5 Options')
 @click.option('--program-version', default=None, type=str, help='Specify version metadata for program.',
               cls=PROSOption, group='V5 Options', hidden=True)
@@ -37,7 +37,7 @@ def upload_cli():
               cls=PROSOption, group='V5 Options', hidden=True)
 @click.option('--compress-bin/--no-compress-bin', 'compress_bin', cls=PROSOption, group='V5 Options', default=True,
               help='Compress the program binary before uploading.')
-@click.option('--description', default=None, type=str, cls=PROSOption, group='V5 Options', 
+@click.option('--description', default="Made with PROS", type=str, cls=PROSOption, group='V5 Options', 
               help='Change the description displayed for the program.')
 @click.option('--name', default=None, type=str, cls=PROSOption, group='V5 Options', 
               help='Change the name of the program.')
@@ -58,12 +58,16 @@ def upload(path: Optional[str], project: Optional[c.Project], port: str, **kwarg
     kwargs['ide_version'] = project.kernel
     kwargs['ide'] = 'PROS'
     name_to_file = {
-        'pros' : 'USER902x',
-        'pizza' : 'USER003x',
-        'planet' : 'USER013x',
-        'alien' : 'USER027x',
-        'ufo' : 'USER029x',
-        'robot' : 'USER010x'
+        'pros' : 'USER902x.bmp',
+        'pizza' : 'USER003x.bmp',
+        'planet' : 'USER013x.bmp',
+        'alien' : 'USER027x.bmp',
+        'ufo' : 'USER029x.bmp',
+        'clawbot' : 'USER010x.bmp',
+        'robot' : 'USER011x.bmp',
+        'question' : 'USER002x.bmp',
+        'power' : 'USER012x.bmp',
+        'X' : 'USER001x.bmp'
     }
     kwargs['icon'] = name_to_file[kwargs['icon']]
     if path is None or os.path.isdir(path):
@@ -104,8 +108,11 @@ def upload(path: Optional[str], project: Optional[c.Project], port: str, **kwarg
     if not port:
         raise dont_send(click.UsageError('No port provided or located. Make sure to specify --target if needed.'))
     if kwargs['target'] == 'v5':
+        kwargs['remote_name'] = kwargs['name'] if kwargs.get("name",None) else kwargs['remote_name']
+        print(kwargs['remote_name'])
         if kwargs['remote_name'] is None:
             kwargs['remote_name'] = os.path.splitext(os.path.basename(path))[0]
+        print(kwargs['remote_name'])
         kwargs['remote_name'] = kwargs['remote_name'].replace('@', '_')
         kwargs['slot'] -= 1
         

--- a/pros/cli/v5_utils.py
+++ b/pros/cli/v5_utils.py
@@ -147,6 +147,26 @@ def cat_metadata(file_name: str, port: str, vid: int):
     device = V5Device(ser)
     print(device.get_file_metadata_by_name(file_name, vid=vid))
 
+@v5.command('rm-program')
+@click.argument('slot')
+@click.argument('port', type=int, required=False, default=None)
+@click.option('--vid', type=int, default=1, cls=PROSOption, hidden=True)
+@default_options
+def rm_program(slot: int, port: str, vid: int):
+    """
+    Remove a program from the flash filesystem
+    """
+    from pros.serial.devices.vex import V5Device
+    from pros.serial.ports import DirectPort
+    port = resolve_v5_port(port, 'system')[0]
+    if not port:
+        return - 1
+
+    base_name = 'slot_' + str(slot)
+    ser = DirectPort(port)
+    device = V5Device(ser)
+    device.erase_file(base_name + '.ini', vid=vid)
+    device.erase_file(base_name + '.bin', vid=vid)
 
 @v5.command('rm-all')
 @click.argument('port', required=False, default=None)

--- a/pros/cli/v5_utils.py
+++ b/pros/cli/v5_utils.py
@@ -162,11 +162,11 @@ def rm_program(slot: int, port: str, vid: int):
     if not port:
         return - 1
 
-    base_name = 'slot_' + str(slot)
+    base_name = f'slot_{slot}'
     ser = DirectPort(port)
     device = V5Device(ser)
-    device.erase_file(base_name + '.ini', vid=vid)
-    device.erase_file(base_name + '.bin', vid=vid)
+    device.erase_file(f'{base_name}.ini', vid=vid)
+    device.erase_file(f'{base_name}.bin', vid=vid)
 
 @v5.command('rm-all')
 @click.argument('port', required=False, default=None)

--- a/pros/serial/devices/vex/v5_device.py
+++ b/pros/serial/devices/vex/v5_device.py
@@ -278,7 +278,7 @@ class V5Device(VEXDevice, SystemDevice):
             'version': kwargs.get('version', '0.0.0') or '0.0.0',
             'name': remote_name,
             'slot': slot,
-            'icon': kwargs.get('icon'),
+            'icon': kwargs.get('icon', default_icon) or default_icon,
             'description': kwargs.get('description', 'Created with PROS'),
             'date': datetime.now().isoformat()
         }
@@ -299,17 +299,17 @@ class V5Device(VEXDevice, SystemDevice):
             action_string = f'Uploading program "{remote_name}"'
             finish_string = f'Finished uploading "{remote_name}"'
             if hasattr(file, 'name'):
-                action_string += f' ({Path(file.name).name})'
-                finish_string += f' ({Path(file.name).name})'
+                action_string += f' ({remote_name if remote_name else Path(file.name).name})'
+                finish_string += f' ({remote_name if remote_name else Path(file.name).name})'
             action_string += f' to V5 slot {slot + 1} on {self.port}'
             if compress_bin:
                 action_string += ' (compressed)'
             ui.echo(action_string)
-
+            print(linked_remote_name)
             remote_base = f'slot_{slot + 1}'
             if target == 'ddr':
                 self.write_file(file, f'{remote_base}.bin', file_len=file_len, type='bin',
-                                target='ddr', run_after=run_after, linked_filename=linked_remote_name, **kwargs)
+                                target='ddr', run_after=run_after, linked_filename=remote_name, **kwargs)
                 return
             if not isinstance(ini, ConfigParser):
                 ini = ConfigParser()
@@ -323,7 +323,7 @@ class V5Device(VEXDevice, SystemDevice):
             logger(__name__).info(f'Created ini: {ini_file}')
 
             if linked_file is not None:
-                self.upload_library(linked_file, remote_name=linked_remote_name, addr=linked_file_addr,
+                self.upload_library(linked_file, remote_name=remote_name, addr=linked_file_addr,
                                     compress=compress_bin, force_upload=kwargs.pop('force_upload_linked', False))
             bin_kwargs = {k: v for k, v in kwargs.items() if v in ['addr']}
             if (quirk & 0xff) == 1:

--- a/pros/serial/devices/vex/v5_device.py
+++ b/pros/serial/devices/vex/v5_device.py
@@ -270,11 +270,15 @@ class V5Device(VEXDevice, SystemDevice):
         project_ini = ConfigParser()
         from semantic_version import Spec
         default_icon = 'USER902x.bmp' if Spec('>=1.0.0-22').match(self.status['cpu0_version']) else 'USER999x.bmp'
+        project_ini['project'] = {
+            'version': str(kwargs.get('ide_version') or get_version()),
+            'ide': str(kwargs.get('ide') or 'PROS')
+        }
         project_ini['program'] = {
             'version': kwargs.get('version', '0.0.0') or '0.0.0',
             'name': remote_name,
             'slot': slot,
-            'icon': kwargs.get('icon', default_icon) or default_icon,
+            'icon': kwargs.get('icon'),
             'description': kwargs.get('description', 'Created with PROS'),
             'date': datetime.now().isoformat()
         }

--- a/pros/serial/devices/vex/v5_device.py
+++ b/pros/serial/devices/vex/v5_device.py
@@ -305,7 +305,6 @@ class V5Device(VEXDevice, SystemDevice):
             if compress_bin:
                 action_string += ' (compressed)'
             ui.echo(action_string)
-            print(linked_remote_name)
             remote_base = f'slot_{slot + 1}'
             if target == 'ddr':
                 self.write_file(file, f'{remote_base}.bin', file_len=file_len, type='bin',


### PR DESCRIPTION
#### Summary:
Adds pros v5 rm-program <slot> command to remove a program from the V5 Brain.
Adds icon, name, and description options to `pros upload` command

Usage:
`pros v5 rm-program 1` will remove the program on slot 1 of the connected V5 Brain.

`pros u --icon alien, name="Alien Project", description="A project with an alien as its icon"` will upload a project to the brain with the custom name, description, and icon provided in the command. The name and description arguments must be `="<value>"` if the value contains spaces. Valid arguments for the icon option are pros (default value), pizza, planet, alien, ufo, robot, clawbot, question, X, and power. 
#### Motivation:
Close the long-overdue PR to add more upload options. Additionally, giving users the ability to choose program description, names, and icons can help them easily differentiate program versions.

##### References (optional):
closes #126 

#### Test Plan:
- [X] - Test all of the icons
- [X] - Test name argument
- [X] - Test description argument
- [X] - Test rm-program command 
