### PR TITLE
 ✨Add m as an alias for make

### DIFF
--- a/pros/cli/build.py
+++ b/pros/cli/build.py
@@ -13,7 +13,7 @@ def build_cli():
     pass
 
 
-@build_cli.command(aliases=['build'])
+@build_cli.command(aliases=['build','m'])
 @project_option()
 @click.argument('build-args', nargs=-1)
 @default_options


### PR DESCRIPTION
#### Summary:
Makes `m` an alias for `pros make`.

#### Motivation:
We currently have: `pros <u, t, ut, mu, mut>`, yet we don't have `pros m`. This PR makes the commands' aliases more uniform.

#### Test Plan:
I ran `pros m` in terminal and it built the project.