### PR TITLE
Use correct linked remote name on develop branch

### DIFF
--- a/pros/serial/devices/vex/v5_device.py
+++ b/pros/serial/devices/vex/v5_device.py
@@ -308,7 +308,7 @@ class V5Device(VEXDevice, SystemDevice):
             remote_base = f'slot_{slot + 1}'
             if target == 'ddr':
                 self.write_file(file, f'{remote_base}.bin', file_len=file_len, type='bin',
-                                target='ddr', run_after=run_after, linked_filename=remote_name, **kwargs)
+                                target='ddr', run_after=run_after, linked_filename=linked_remote_name, **kwargs)
                 return
             if not isinstance(ini, ConfigParser):
                 ini = ConfigParser()
@@ -322,7 +322,7 @@ class V5Device(VEXDevice, SystemDevice):
             logger(__name__).info(f'Created ini: {ini_file}')
 
             if linked_file is not None:
-                self.upload_library(linked_file, remote_name=remote_name, addr=linked_file_addr,
+                self.upload_library(linked_file, remote_name=linked_remote_name, addr=linked_file_addr,
                                     compress=compress_bin, force_upload=kwargs.pop('force_upload_linked', False))
             bin_kwargs = {k: v for k, v in kwargs.items() if v in ['addr']}
             if (quirk & 0xff) == 1:


### PR DESCRIPTION
#### Summary:
#199  was somehow still only on the master branch even after the back merge. 
Fix linked_remote_name on develop

