### PR TITLE
✨Set team number and robot name

### DIFF
--- a/pros/cli/misc_commands.py
+++ b/pros/cli/misc_commands.py
@@ -65,7 +65,6 @@ def read_variable(variable):
     if port == None:
         return
     device = vex.V5Device(DirectPort(port))
-    value = device.kv_read(variable)
-    print(value)
-    ui.finalize('readVariable', f'{variable}\'s read value is {value}')
+    value = device.kv_read(variable).decode()
+    ui.finalize('readVariable', f'Value of \'{variable}\' : {value}')
     

--- a/pros/cli/misc_commands.py
+++ b/pros/cli/misc_commands.py
@@ -51,7 +51,7 @@ def set_variable(variable, value):
         return
     device = vex.V5Device(DirectPort(port))
     device.kv_write(variable, value)
-    ui.finalize('setVariable', f'{variable} set to {value}')
+    ui.finalize('setVariable', f'{variable} set to {value[:255]}')
 
 @misc_commands_cli.command(aliases=['rv'], short_help='Read a kernel variable from a connected V5 device')
 @default_options

--- a/pros/cli/misc_commands.py
+++ b/pros/cli/misc_commands.py
@@ -36,35 +36,3 @@ def upgrade(force_check, no_install):
                 ui.logger(__name__).error(f'This manifest cannot perform the upgrade.')
                 return -3
             ui.finalize('upgradeComplete', manager.perform_upgrade())
-
-@misc_commands_cli.command(aliases=['sv'], short_help='Set a kernel variable on a connected V5 device')
-@default_options
-@click.argument('variable', type=click.Choice(['teamnumber', 'robotname']), required=True)
-@click.argument('value', required=True, type=click.STRING, nargs=1)
-def set_variable(variable, value):
-    import pros.serial.devices.vex as vex
-    from pros.serial.ports import DirectPort
-
-    # Get the connected v5 device
-    port = resolve_v5_port(None, 'system')[0]
-    if port == None:
-        return
-    device = vex.V5Device(DirectPort(port))
-    device.kv_write(variable, value)
-    ui.finalize('setVariable', f'{variable} set to {value[:255]}')
-
-@misc_commands_cli.command(aliases=['rv'], short_help='Read a kernel variable from a connected V5 device')
-@default_options
-@click.argument('variable', type=click.Choice(['teamnumber', 'robotname']), required=True)
-def read_variable(variable):
-    import pros.serial.devices.vex as vex
-    from pros.serial.ports import DirectPort
-
-    # Get the connected v5 device
-    port = resolve_v5_port(None, 'system')[0]
-    if port == None:
-        return
-    device = vex.V5Device(DirectPort(port))
-    value = device.kv_read(variable).decode()
-    ui.finalize('readVariable', f'Value of \'{variable}\' : {value}')
-    

--- a/pros/cli/misc_commands.py
+++ b/pros/cli/misc_commands.py
@@ -2,13 +2,6 @@ import pros.common.ui as ui
 from pros.cli.common import *
 from pros.ga.analytics import analytics
 
-@pros_root
-def set_variable():
-    pass
-
-@pros_root
-def read_variable():
-    pass
 
 @pros_root
 def misc_commands_cli():
@@ -44,7 +37,7 @@ def upgrade(force_check, no_install):
                 return -3
             ui.finalize('upgradeComplete', manager.perform_upgrade())
 
-@set_variable.command(aliases=['sv'])
+@misc_commands_cli.command(aliases=['sv'], short_help='Set a kernel variable on a connected V5 device')
 @default_options
 @click.argument('variable', type=click.Choice(['teamnumber', 'robotname']), required=True)
 @click.argument('value', required=True, type=click.STRING, nargs=1)
@@ -60,7 +53,7 @@ def set_variable(variable, value):
     device.kv_write(variable, value)
     ui.finalize('setVariable', f'{variable} set to {value}')
 
-@read_variable.command(aliases=['rv'])
+@misc_commands_cli.command(aliases=['rv'], short_help='Read a kernel variable from a connected V5 device')
 @default_options
 @click.argument('variable', type=click.Choice(['teamnumber', 'robotname']), required=True)
 def read_variable(variable):

--- a/pros/cli/misc_commands.py
+++ b/pros/cli/misc_commands.py
@@ -3,6 +3,14 @@ from pros.cli.common import *
 from pros.ga.analytics import analytics
 
 @pros_root
+def set_variable():
+    pass
+
+@pros_root
+def read_variable():
+    pass
+
+@pros_root
 def misc_commands_cli():
     pass
 
@@ -35,3 +43,36 @@ def upgrade(force_check, no_install):
                 ui.logger(__name__).error(f'This manifest cannot perform the upgrade.')
                 return -3
             ui.finalize('upgradeComplete', manager.perform_upgrade())
+
+@set_variable.command(aliases=['sv'])
+@default_options
+@click.argument('variable', type=click.Choice(['teamnumber', 'robotname']), required=True)
+@click.argument('value', required=True, type=click.STRING, nargs=1)
+def set_variable(variable, value):
+    import pros.serial.devices.vex as vex
+    from pros.serial.ports import DirectPort
+
+    # Get the connected v5 device
+    port = resolve_v5_port(None, 'system')[0]
+    if port == None:
+        return
+    device = vex.V5Device(DirectPort(port))
+    device.kv_write(variable, value)
+    ui.finalize('setVariable', f'{variable} set to {value}')
+
+@read_variable.command(aliases=['rv'])
+@default_options
+@click.argument('variable', type=click.Choice(['teamnumber', 'robotname']), required=True)
+def read_variable(variable):
+    import pros.serial.devices.vex as vex
+    from pros.serial.ports import DirectPort
+
+    # Get the connected v5 device
+    port = resolve_v5_port(None, 'system')[0]
+    if port == None:
+        return
+    device = vex.V5Device(DirectPort(port))
+    value = device.kv_read(variable)
+    print(value)
+    ui.finalize('readVariable', f'{variable}\'s read value is {value}')
+    

--- a/pros/cli/v5_utils.py
+++ b/pros/cli/v5_utils.py
@@ -290,3 +290,35 @@ def capture(file_name: str, port: str, force: bool = False):
         w.write(file_, i_data)
 
     print(f'Saved screen capture to {file_name}')
+
+@v5.command(aliases=['sv'], short_help='Set a kernel variable on a connected V5 device')
+@click.argument('variable', type=click.Choice(['teamnumber', 'robotname']), required=True)
+@click.argument('value', required=True, type=click.STRING, nargs=1)
+@default_options
+def set_variable(variable, value):
+    import pros.serial.devices.vex as vex
+    from pros.serial.ports import DirectPort
+
+    # Get the connected v5 device
+    port = resolve_v5_port(None, 'system')[0]
+    if port == None:
+        return
+    device = vex.V5Device(DirectPort(port))
+    device.kv_write(variable, value)
+    print(f'{variable} set to {value[:253]}')
+
+@v5.command(aliases=['rv'], short_help='Read a kernel variable from a connected V5 device')
+@click.argument('variable', type=click.Choice(['teamnumber', 'robotname']), required=True)
+@default_options
+def read_variable(variable):
+    import pros.serial.devices.vex as vex
+    from pros.serial.ports import DirectPort
+
+    # Get the connected v5 device
+    port = resolve_v5_port(None, 'system')[0]
+    if port == None:
+        return
+    device = vex.V5Device(DirectPort(port))
+    value = device.kv_read(variable).decode()
+    print(f'Value of \'{variable}\' : {value}')
+    

--- a/pros/cli/v5_utils.py
+++ b/pros/cli/v5_utils.py
@@ -291,7 +291,7 @@ def capture(file_name: str, port: str, force: bool = False):
 
     print(f'Saved screen capture to {file_name}')
 
-@v5.command(aliases=['sv'], short_help='Set a kernel variable on a connected V5 device')
+@v5.command(aliases=['sv', 'set'], short_help='Set a kernel variable on a connected V5 device')
 @click.argument('variable', type=click.Choice(['teamnumber', 'robotname']), required=True)
 @click.argument('value', required=True, type=click.STRING, nargs=1)
 @default_options
@@ -307,7 +307,7 @@ def set_variable(variable, value):
     device.kv_write(variable, value)
     print(f'{variable} set to {value[:253]}')
 
-@v5.command(aliases=['rv'], short_help='Read a kernel variable from a connected V5 device')
+@v5.command(aliases=['rv', 'get'], short_help='Read a kernel variable from a connected V5 device')
 @click.argument('variable', type=click.Choice(['teamnumber', 'robotname']), required=True)
 @default_options
 def read_variable(variable):

--- a/pros/serial/devices/vex/v5_device.py
+++ b/pros/serial/devices/vex/v5_device.py
@@ -906,11 +906,12 @@ class V5Device(VEXDevice, SystemDevice):
     def kv_write(self, kv: str, payload: Union[Iterable, bytes, bytearray, str]):
         logger(__name__).debug('Sending ext 0x2f command')
         encoded_kv = f'{kv}\0'.encode(encoding='ascii')
+        # Trim down size of payload to fit within the 255 byte limit and add null terminator.
+        payload = payload[:253] + "\0"
         if isinstance(payload, str):
             payload = payload.encode(encoding='ascii')
-        trimmed_payload = payload[:255]
-        tx_fmt =f'<{len(encoded_kv)}s{len(trimmed_payload)}s'
-        tx_payload = struct.pack(tx_fmt, encoded_kv, trimmed_payload)
+        tx_fmt =f'<{len(encoded_kv)}s{len(payload)}s'
+        tx_payload = struct.pack(tx_fmt, encoded_kv, payload)
         ret = self._txrx_ext_packet(0x2f, tx_payload, 0)
         logger(__name__).debug('Completed ext 0x2f command')
         return ret

--- a/pros/serial/devices/vex/v5_device.py
+++ b/pros/serial/devices/vex/v5_device.py
@@ -892,6 +892,29 @@ class V5Device(VEXDevice, SystemDevice):
         self._txrx_ext_struct(0x28, [], '')
         logger(__name__).debug('Completed ext 0x28 command')
 
+    @retries
+    def kv_read(self, kv: str) -> bytearray:
+        logger(__name__).debug('Sending ext 0x2e command')
+        encoded_kv = f'{kv}\0'.encode(encoding='ascii')
+        tx_payload = struct.pack(f'<{len(encoded_kv)}s', encoded_kv)
+        rx_fmt = "<I{}s".format(255)
+        ret = self._txrx_ext_struct(0x2e, tx_payload, rx_fmt, check_ack=False)[1]
+        logger(__name__).debug('Completed ext 0x2e command')
+        return ret
+
+    @retries
+    def kv_write(self, kv: str, payload: Union[Iterable, bytes, bytearray, str]):
+        logger(__name__).debug('Sending ext 0x2f command')
+        encoded_kv = f'{kv}\0'.encode(encoding='ascii')
+        if isinstance(payload, str):
+            payload = payload.encode(encoding='ascii')
+        trimmed_payload = payload[:255]
+        tx_fmt =f'<{len(encoded_kv)}s{len(trimmed_payload)}s'
+        tx_payload = struct.pack(tx_fmt, encoded_kv, trimmed_payload)
+        ret = self._txrx_ext_packet(0x2f, tx_payload, 0)
+        logger(__name__).debug('Completed ext 0x2f command')
+        return ret
+
     def _txrx_ext_struct(self, command: int, tx_data: Union[Iterable, bytes, bytearray],
                          unpack_fmt: str, check_length: bool = True, check_ack: bool = True,
                          timeout: Optional[float] = None) -> Tuple:


### PR DESCRIPTION
#### Summary:
Allows the users to read and set kernel variables (currently just teamnumber and robotname)

#### Motivation:
A new tournament management system was introduced for Worlds 2022, which needs teams to have their teamnumber set on the brain. PROS does not yet have this feature.

#### Test Plan:
Tested both read and write for 'teamnumber' and 'robotname' kernel variables. Values are set and returned as expected.
Values that are too long for the screen are truncated.
