### PR TITLE
✨Set team number and robot name

### DIFF
--- a/pros/cli/v5_utils.py
+++ b/pros/cli/v5_utils.py
@@ -304,8 +304,8 @@ def set_variable(variable, value):
     if port == None:
         return
     device = vex.V5Device(DirectPort(port))
-    device.kv_write(variable, value)
-    print(f'{variable} set to {value[:253]}')
+    actual_value = device.kv_write(variable, value).decode()
+    print(f'Value of \'{variable}\' set to : {actual_value}')
 
 @v5.command(aliases=['rv', 'get'], short_help='Read a kernel variable from a connected V5 device')
 @click.argument('variable', type=click.Choice(['teamnumber', 'robotname']), required=True)
@@ -320,4 +320,4 @@ def read_variable(variable):
         return
     device = vex.V5Device(DirectPort(port))
     value = device.kv_read(variable).decode()
-    print(f'Value of \'{variable}\' : {value}')
+    print(f'Value of \'{variable}\' is : {value}')

--- a/pros/cli/v5_utils.py
+++ b/pros/cli/v5_utils.py
@@ -290,3 +290,34 @@ def capture(file_name: str, port: str, force: bool = False):
         w.write(file_, i_data)
 
     print(f'Saved screen capture to {file_name}')
+
+@v5.command(aliases=['sv', 'set'], short_help='Set a kernel variable on a connected V5 device')
+@click.argument('variable', type=click.Choice(['teamnumber', 'robotname']), required=True)
+@click.argument('value', required=True, type=click.STRING, nargs=1)
+@default_options
+def set_variable(variable, value):
+    import pros.serial.devices.vex as vex
+    from pros.serial.ports import DirectPort
+
+    # Get the connected v5 device
+    port = resolve_v5_port(None, 'system')[0]
+    if port == None:
+        return
+    device = vex.V5Device(DirectPort(port))
+    device.kv_write(variable, value)
+    print(f'{variable} set to {value[:253]}')
+
+@v5.command(aliases=['rv', 'get'], short_help='Read a kernel variable from a connected V5 device')
+@click.argument('variable', type=click.Choice(['teamnumber', 'robotname']), required=True)
+@default_options
+def read_variable(variable):
+    import pros.serial.devices.vex as vex
+    from pros.serial.ports import DirectPort
+
+    # Get the connected v5 device
+    port = resolve_v5_port(None, 'system')[0]
+    if port == None:
+        return
+    device = vex.V5Device(DirectPort(port))
+    value = device.kv_read(variable).decode()
+    print(f'Value of \'{variable}\' : {value}')

--- a/pros/serial/devices/vex/v5_device.py
+++ b/pros/serial/devices/vex/v5_device.py
@@ -920,7 +920,7 @@ class V5Device(VEXDevice, SystemDevice):
         tx_payload = struct.pack(tx_fmt, encoded_kv, payload)
         ret = self._txrx_ext_packet(0x2f, tx_payload, 1, check_length=False, check_ack=True)
         logger(__name__).debug('Completed ext 0x2f command')
-        return ret
+        return payload
 
     def _txrx_ext_struct(self, command: int, tx_data: Union[Iterable, bytes, bytearray],
                          unpack_fmt: str, check_length: bool = True, check_ack: bool = True,

--- a/pros/serial/devices/vex/v5_device.py
+++ b/pros/serial/devices/vex/v5_device.py
@@ -898,7 +898,7 @@ class V5Device(VEXDevice, SystemDevice):
         encoded_kv = f'{kv}\0'.encode(encoding='ascii')
         tx_payload = struct.pack(f'<{len(encoded_kv)}s', encoded_kv)
         # Because the length of the kernel variables is not known, use None to indicate we are recieving an unknown length.
-        ret = self._txrx_ext_struct(0x2e, tx_payload, None, check_length=False, check_ack=True)[0]   
+        ret = self._txrx_ext_packet(0x2e, tx_payload, 1, check_length=False, check_ack=True)
         logger(__name__).debug('Completed ext 0x2e command')
         return ret
 
@@ -910,15 +910,15 @@ class V5Device(VEXDevice, SystemDevice):
             'teamnumber': 7,
             'robotname': 16
         }
-        if len(kv) > kv_to_max_bytes.get(kv, 254):
-            logger(__name__).info(f'{kv} is longer than the maximum supported length {kv_to_max_bytes[kv]}, truncating.')
+        if len(payload) > kv_to_max_bytes.get(kv, 254):
+            print(f'Truncating input to meet maximum value length ({kv_to_max_bytes[kv]} characters).')
         # Trim down size of payload to fit within the 255 byte limit and add null terminator.
         payload = payload[:kv_to_max_bytes.get(kv, 254)] + "\0"
         if isinstance(payload, str):
             payload = payload.encode(encoding='ascii')
         tx_fmt =f'<{len(encoded_kv)}s{len(payload)}s'
         tx_payload = struct.pack(tx_fmt, encoded_kv, payload)
-        ret = self._txrx_ext_packet(0x2f, tx_payload, None, check_length=False, check_ack=True)
+        ret = self._txrx_ext_packet(0x2f, tx_payload, 1, check_length=False, check_ack=True)
         logger(__name__).debug('Completed ext 0x2f command')
         return ret
 

--- a/pros/serial/devices/vex/v5_device.py
+++ b/pros/serial/devices/vex/v5_device.py
@@ -892,6 +892,36 @@ class V5Device(VEXDevice, SystemDevice):
         self._txrx_ext_struct(0x28, [], '')
         logger(__name__).debug('Completed ext 0x28 command')
 
+    @retries
+    def kv_read(self, kv: str) -> bytearray:
+        logger(__name__).debug('Sending ext 0x2e command')
+        encoded_kv = f'{kv}\0'.encode(encoding='ascii')
+        tx_payload = struct.pack(f'<{len(encoded_kv)}s', encoded_kv)
+        # Because the length of the kernel variables is not known, use None to indicate we are recieving an unknown length.
+        ret = self._txrx_ext_struct(0x2e, tx_payload, None, check_length=False, check_ack=True)[0]   
+        logger(__name__).debug('Completed ext 0x2e command')
+        return ret
+
+    @retries
+    def kv_write(self, kv: str, payload: Union[Iterable, bytes, bytearray, str]):
+        logger(__name__).debug('Sending ext 0x2f command')
+        encoded_kv = f'{kv}\0'.encode(encoding='ascii')
+        kv_to_max_bytes = {
+            'teamnumber': 7,
+            'robotname': 16
+        }
+        if len(kv) > kv_to_max_bytes.get(kv, 254):
+            logger(__name__).info(f'{kv} is longer than the maximum supported length {kv_to_max_bytes[kv]}, truncating.')
+        # Trim down size of payload to fit within the 255 byte limit and add null terminator.
+        payload = payload[:kv_to_max_bytes.get(kv, 254)] + "\0"
+        if isinstance(payload, str):
+            payload = payload.encode(encoding='ascii')
+        tx_fmt =f'<{len(encoded_kv)}s{len(payload)}s'
+        tx_payload = struct.pack(tx_fmt, encoded_kv, payload)
+        ret = self._txrx_ext_packet(0x2f, tx_payload, None, check_length=False, check_ack=True)
+        logger(__name__).debug('Completed ext 0x2f command')
+        return ret
+
     def _txrx_ext_struct(self, command: int, tx_data: Union[Iterable, bytes, bytearray],
                          unpack_fmt: str, check_length: bool = True, check_ack: bool = True,
                          timeout: Optional[float] = None) -> Tuple:


### PR DESCRIPTION
#### Summary:
Allows users to set and get their brain's team number and robot name. 

#### Motivation:
Initial release of this feature broke uploading and was promptly removed. This PR adds back the feature without breaking uploading.

#### Test Plan:
- [x] Able to set teamnumber and robotname
- [x] Able to get teamnumber and robotname
- [x] Doesn't break upload

All of the above are true for me, someone else should test them though.