### PR TITLE
✨Terminal file output

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "pros.showInstallOnStartup": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "pros.showInstallOnStartup": false
-}

--- a/pros/cli/terminal.py
+++ b/pros/cli/terminal.py
@@ -96,7 +96,6 @@ def terminal(port: str, backend: str, **kwargs):
             pass
 
     if kwargs.get('output', None):
-        print(f"arguments in argument dictionary: {kwargs}")
         output_file = kwargs['output']
         print(f'Redirecting Terminal Output to File: {output_file}')
         sys.stdout = TerminalOutput(f'{output_file}')

--- a/pros/cli/terminal.py
+++ b/pros/cli/terminal.py
@@ -88,17 +88,22 @@ def terminal(port: str, backend: str, **kwargs):
     class TerminalOutput(object):
         def __init__(self, file):
             self.terminal = sys.stdout
-            self.log = open(file, "a")
+            self.log = open(file, 'a')
         def write(self, data):
             self.terminal.write(data)
             self.log.write(data) 
         def flush(self):
             pass
+        def end(self):
+            self.log.close()
 
+    output = None
     if kwargs.get('output', None):
         output_file = kwargs['output']
+        output = TerminalOutput(f'{output_file}')
+        term.console.output = output
+        sys.stdout = output
         print(f'Redirecting Terminal Output to File: {output_file}')
-        sys.stdout = TerminalOutput(f'{output_file}')
     else:
         sys.stdout = sys.__stdout__
 
@@ -106,5 +111,8 @@ def terminal(port: str, backend: str, **kwargs):
     term.start()
     while not term.alive.is_set():
         time.sleep(0.005)
+    sys.stdout = sys.__stdout__
+    if output:
+        output.end()
     term.join()
     logger(__name__).info('CLI Main Thread Dying')

--- a/pros/cli/terminal.py
+++ b/pros/cli/terminal.py
@@ -91,9 +91,9 @@ def terminal(port: str, backend: str, **kwargs):
         device = devices.vex.V5UserDevice(ser)
     term = Terminal(device, request_banner=kwargs.pop('request_banner', True))
 
-    if kwargs.get('output', None):
-        return None
-    else:
+    #if kwargs.get('output', None):
+       # return None
+    #else:
 
 
 

--- a/pros/cli/terminal.py
+++ b/pros/cli/terminal.py
@@ -30,7 +30,7 @@ def terminal_cli():
               help='Specify 2 ports for the "share" backend. The default option deterministically selects ports '
                    'based on the serial port name')
 @click.option('--banner/--no-banner', 'request_banner', default=True)
-@click.option('--output',is_eager = True, help='Redirect terminal output to a file', default=None)
+@click.option('--output', nargs = 1, type=str, is_eager = True, help='Redirect terminal output to a file', default=None)
 
 def terminal(port: str, backend: str, **kwargs):
     """
@@ -43,10 +43,6 @@ def terminal(port: str, backend: str, **kwargs):
 
     Note: share backend is not yet implemented.
     """
-    def redirect_file_option(f: Union[click.Command, Callable]): 
-        def callback(ctx: click.Context, param: click.core.Parameter, value: Any):
-            if value is None or value[0] is None:
-                return None
             
     analytics.send("terminal")
     from pros.serial.devices.vex.v5_user_device import V5UserDevice
@@ -91,9 +87,10 @@ def terminal(port: str, backend: str, **kwargs):
         device = devices.vex.V5UserDevice(ser)
     term = Terminal(device, request_banner=kwargs.pop('request_banner', True))
 
-    #if kwargs.get('output', None):
-       # return None
-    #else:
+    if kwargs.get('output', None):
+        print(f"arguments in argument dictionary: {kwargs}")
+        output_file = kwargs['output']
+        print(f'Redirecting Terminal Output to File: {output_file}')
 
 
 

--- a/pros/cli/terminal.py
+++ b/pros/cli/terminal.py
@@ -103,7 +103,7 @@ def terminal(port: str, backend: str, **kwargs):
         output = TerminalOutput(f'{output_file}')
         term.console.output = output
         sys.stdout = output
-       logger(__name__).info(f'Redirecting Terminal Output to File: {output_file}')
+        logger(__name__).info(f'Redirecting Terminal Output to File: {output_file}')
     else:
         sys.stdout = sys.__stdout__
 

--- a/pros/cli/terminal.py
+++ b/pros/cli/terminal.py
@@ -3,6 +3,7 @@ import signal
 import time
 
 import click
+import sys
 
 import pros.conductor as c
 import pros.serial.devices as devices
@@ -11,7 +12,6 @@ from pros.common.utils import logger
 from .common import default_options, resolve_v5_port, resolve_cortex_port, pros_root
 from pros.serial.ports.v5_wireless_port import V5WirelessPort
 from pros.ga.analytics import analytics
-from pros.common.utils import *
 
 @pros_root
 def terminal_cli():
@@ -42,13 +42,10 @@ def terminal(port: str, backend: str, **kwargs):
     may be preferred when "share" doesn't perform adequately.
 
     Note: share backend is not yet implemented.
-    """
-            
+    """       
     analytics.send("terminal")
     from pros.serial.devices.vex.v5_user_device import V5UserDevice
     from pros.serial.terminal import Terminal
-
-    
     is_v5_user_joystick = False
     if port == 'default':
         project_path = c.Project.find_project(os.getcwd())
@@ -102,7 +99,7 @@ def terminal(port: str, backend: str, **kwargs):
         print(f"arguments in argument dictionary: {kwargs}")
         output_file = kwargs['output']
         print(f'Redirecting Terminal Output to File: {output_file}')
-        sys.stdout = TerminalOutput(f'{output_file}')§
+        sys.stdout = TerminalOutput(f'{output_file}')
     else:
         sys.stdout = sys.__stdout__
 

--- a/pros/cli/terminal.py
+++ b/pros/cli/terminal.py
@@ -88,12 +88,23 @@ def terminal(port: str, backend: str, **kwargs):
         device = devices.vex.V5UserDevice(ser)
     term = Terminal(device, request_banner=kwargs.pop('request_banner', True))
 
+    class TerminalOutput(object):
+        def __init__(self, file):
+            self.terminal = sys.stdout
+            self.log = open(file, "a")
+        def write(self, data):
+            self.terminal.write(data)
+            self.log.write(data) 
+        def flush(self):
+            pass
+
     if kwargs.get('output', None):
         print(f"arguments in argument dictionary: {kwargs}")
         output_file = kwargs['output']
         print(f'Redirecting Terminal Output to File: {output_file}')
-        with open(f'{output_file}', 'a') as file:
-            sys.stdout = file
+        sys.stdout = TerminalOutput(f'{output_file}')§
+    else:
+        sys.stdout = sys.__stdout__
 
     signal.signal(signal.SIGINT, term.stop)
     term.start()

--- a/pros/cli/terminal.py
+++ b/pros/cli/terminal.py
@@ -103,7 +103,7 @@ def terminal(port: str, backend: str, **kwargs):
         output = TerminalOutput(f'{output_file}')
         term.console.output = output
         sys.stdout = output
-        print(f'Redirecting Terminal Output to File: {output_file}')
+       logger(__name__).info(f'Redirecting Terminal Output to File: {output_file}')
     else:
         sys.stdout = sys.__stdout__
 

--- a/pros/cli/terminal.py
+++ b/pros/cli/terminal.py
@@ -47,6 +47,7 @@ def terminal(port: str, backend: str, **kwargs):
     analytics.send("terminal")
     from pros.serial.devices.vex.v5_user_device import V5UserDevice
     from pros.serial.terminal import Terminal
+
     
     is_v5_user_joystick = False
     if port == 'default':
@@ -91,8 +92,8 @@ def terminal(port: str, backend: str, **kwargs):
         print(f"arguments in argument dictionary: {kwargs}")
         output_file = kwargs['output']
         print(f'Redirecting Terminal Output to File: {output_file}')
-
-
+        with open(f'{output_file}', 'a') as file:
+            sys.stdout = file
 
     signal.signal(signal.SIGINT, term.stop)
     term.start()

--- a/pros/cli/terminal.py
+++ b/pros/cli/terminal.py
@@ -11,6 +11,7 @@ from pros.common.utils import logger
 from .common import default_options, resolve_v5_port, resolve_cortex_port, pros_root
 from pros.serial.ports.v5_wireless_port import V5WirelessPort
 from pros.ga.analytics import analytics
+from pros.common.utils import *
 
 @pros_root
 def terminal_cli():
@@ -29,6 +30,8 @@ def terminal_cli():
               help='Specify 2 ports for the "share" backend. The default option deterministically selects ports '
                    'based on the serial port name')
 @click.option('--banner/--no-banner', 'request_banner', default=True)
+@click.option('--output',is_eager = True, help='Redirect terminal output to a file', default=None)
+
 def terminal(port: str, backend: str, **kwargs):
     """
     Open a terminal to a serial port
@@ -40,9 +43,15 @@ def terminal(port: str, backend: str, **kwargs):
 
     Note: share backend is not yet implemented.
     """
+    def redirect_file_option(f: Union[click.Command, Callable]): 
+        def callback(ctx: click.Context, param: click.core.Parameter, value: Any):
+            if value is None or value[0] is None:
+                return None
+            
     analytics.send("terminal")
     from pros.serial.devices.vex.v5_user_device import V5UserDevice
     from pros.serial.terminal import Terminal
+    
     is_v5_user_joystick = False
     if port == 'default':
         project_path = c.Project.find_project(os.getcwd())
@@ -81,6 +90,12 @@ def terminal(port: str, backend: str, **kwargs):
     else:
         device = devices.vex.V5UserDevice(ser)
     term = Terminal(device, request_banner=kwargs.pop('request_banner', True))
+
+    if kwargs.get('output', None):
+        return None
+    else:
+
+
 
     signal.signal(signal.SIGINT, term.stop)
     term.start()


### PR DESCRIPTION
#### Summary:
Added terminal option that sends output to a file by redirecting the standard output stream. Output is displayed in both the terminal and file. 

##### References (optional):
Closes #108 (Add File Redirect Option to Terminal)

#### Test Plan:
Using the command `pros terminal --output [filename]` should show output in the terminal and the selected file. Afterwards, it should return to the original state of the standard output stream (terminal only).
