### PR TITLE
✨Version Display On Error

### DIFF
--- a/pros/cli/click_classes.py
+++ b/pros/cli/click_classes.py
@@ -3,6 +3,7 @@ from typing import *
 
 import click.decorators
 from click import ClickException
+from pros.conductor.project import Project as p
 from pros.common.utils import get_version
 
 
@@ -157,4 +158,8 @@ class PROSCommandCollection(PROSFormatted, click.CommandCollection):
             super(PROSCommandCollection, self).invoke(*args, **kwargs)
         except ClickException as e:
             click.echo("PROS-CLI Version:  {}".format(get_version()))
+            isProject = p.find_project("")
+            if (isProject): #check if there is a project
+                curr_proj = p()
+                click.echo("PROS-Kernel Version: {}".format(curr_proj.kernel))
             raise e

--- a/pros/cli/click_classes.py
+++ b/pros/cli/click_classes.py
@@ -2,6 +2,8 @@ from collections import defaultdict
 from typing import *
 
 import click.decorators
+from click import ClickException
+from pros.common.utils import get_version
 
 
 class PROSFormatted(click.BaseCommand):
@@ -56,7 +58,6 @@ class PROSFormatted(click.BaseCommand):
                 formatter.write_dl(options)
 
         self.format_commands(ctx, formatter)
-
 
 class PROSCommand(PROSFormatted, click.Command):
     pass
@@ -148,4 +149,12 @@ class PROSRoot(PROSGroup):
 
 
 class PROSCommandCollection(PROSFormatted, click.CommandCollection):
-    pass
+    def invoke(self, *args, **kwargs):
+        # should change none of the behavior of invoke / ClientException
+        # should just sit in the pipeline and do a quick echo before
+        # letting everything else go through.
+        try:
+            super(PROSCommandCollection, self).invoke(*args, **kwargs)
+        except ClickException as e:
+            click.echo("PROS-CLI Version:  {}".format(get_version()))
+            raise e

--- a/pros/cli/main.py
+++ b/pros/cli/main.py
@@ -46,7 +46,8 @@ def main():
         ctx_obj = {}
         click_handler = pros.common.ui.log.PROSLogHandler(ctx_obj=ctx_obj)
         ctx_obj['click_handler'] = click_handler
-        formatter = pros.common.ui.log.PROSLogFormatter('%(levelname)s - %(name)s:%(funcName)s - %(message)s', ctx_obj)
+        formatter = pros.common.ui.log.PROSLogFormatter('%(levelname)s - %(name)s:%(funcName)s - %(message)s - pros-cli version:%(version)s', 
+            ctx_obj, defaults={'version': get_version()})
         click_handler.setFormatter(formatter)
         logging.basicConfig(level=logging.WARNING, handlers=[click_handler])
         cli.main(prog_name='pros', obj=ctx_obj)

--- a/pros/cli/main.py
+++ b/pros/cli/main.py
@@ -46,8 +46,8 @@ def main():
         ctx_obj = {}
         click_handler = pros.common.ui.log.PROSLogHandler(ctx_obj=ctx_obj)
         ctx_obj['click_handler'] = click_handler
-        formatter = pros.common.ui.log.PROSLogFormatter('%(levelname)s - %(name)s:%(funcName)s - %(message)s - pros-cli version:%(version)s', 
-            ctx_obj, defaults={'version': get_version()})
+        formatter = pros.common.ui.log.PROSLogFormatter('%(levelname)s - %(name)s:%(funcName)s - %(message)s - pros-cli version:{version}'
+            .format(version = get_version()), ctx_obj)
         click_handler.setFormatter(formatter)
         logging.basicConfig(level=logging.WARNING, handlers=[click_handler])
         cli.main(prog_name='pros', obj=ctx_obj)


### PR DESCRIPTION
#### Summary:
Added version numbering to errors. Identified two places where errors are caught: ClickExceptions & Logger. Logger errors are thrown by logic related. For logger errors, the CLI version will be shown within the formatter. For ClickExceptions, an overloaded method will catch them in it's parent method, display errors, then send the error back to the parent method to be dealt with normally. 

#### Motivation:
See #187.

#### Test Plan:
- Attempt an error outside of a project directory and only see CLI version.
- Attempt an error inside of a project directory and see CLI + Kernel version.

- Kernel Version: 3.7.0, CLI Version: 3.3.3
`pros upload` in newly created project folder with the versions above where computer is not connected to brain.
<img width="564" alt="image" src="https://user-images.githubusercontent.com/44490900/194205187-886aecbe-49ec-409e-8a19-3146e42155fb.png">

  