### PR TITLE
✨Run make clean after uninstall template

### DIFF
--- a/pros/cli/conductor.py
+++ b/pros/cli/conductor.py
@@ -163,11 +163,12 @@ def upgrade(ctx: click.Context, project: c.Project, query: c.BaseTemplate, **kwa
 @click.option('--remove-user', is_flag=True, default=False, help='Also remove user files')
 @click.option('--remove-empty-dirs/--no-remove-empty-dirs', 'remove_empty_directories', is_flag=True, default=True,
               help='Remove empty directories when removing files')
+@click.option('--no-make-clean', is_flag=True, default=True, help='Do not run make clean after removing')
 @project_option()
 @template_query()
 @default_options
 def uninstall_template(project: c.Project, query: c.BaseTemplate, remove_user: bool,
-                       remove_empty_directories: bool = False):
+                       remove_empty_directories: bool = False, no_make_clean: bool = False):
     """
     Uninstall a template from a PROS project
 
@@ -176,9 +177,9 @@ def uninstall_template(project: c.Project, query: c.BaseTemplate, remove_user: b
     analytics.send("uninstall-template")
     c.Conductor().remove_template(project, query, remove_user=remove_user,
                                   remove_empty_directories=remove_empty_directories)
-    # make clean
-    with ui.Notification():
-        project.compile(["clean"])
+    if no_make_clean:
+        with ui.Notification():
+            project.compile(["clean"])
 
 
 @conductor.command('new-project', aliases=['new', 'create-project'])

--- a/pros/cli/conductor.py
+++ b/pros/cli/conductor.py
@@ -176,6 +176,9 @@ def uninstall_template(project: c.Project, query: c.BaseTemplate, remove_user: b
     analytics.send("uninstall-template")
     c.Conductor().remove_template(project, query, remove_user=remove_user,
                                   remove_empty_directories=remove_empty_directories)
+    # make clean
+    with ui.Notification():
+        project.compile(["clean"])
 
 
 @conductor.command('new-project', aliases=['new', 'create-project'])


### PR DESCRIPTION
#### Summary:
Runs make clean after removing a template from a project, adds a flag to control this behavior (on by default)

#### Motivation:
If a user removes a template it should make clean automatically on the project

##### References (optional):
Closes #234 

#### Test Plan:
Create project, uninstall okapilib and see that it makes clean after removing
Install okapilib again, uninstall it with flag to make it not run make clean