### PR TITLE
✨ Create flag for new PROS project to choose between 3 or 4

### DIFF
--- a/pros/cli/conductor.py
+++ b/pros/cli/conductor.py
@@ -198,6 +198,8 @@ def uninstall_template(project: c.Project, query: c.BaseTemplate, remove_user: b
               help='Compile the project after creation')
 @click.option('--build-cache', is_flag=True, default=None, show_default=False,
               help='Build compile commands cache after creation. Overrides --compile-after if both are specified.')
+@click.option('--pros-4', is_flag=True, default=False, show_default=True,
+              help='Create a PROS 4 project instead of a PROS 3 project')
 @click.pass_context
 @default_options
 def new_project(ctx: click.Context, path: str, target: str, version: str,

--- a/pros/conductor/conductor.py
+++ b/pros/conductor/conductor.py
@@ -222,7 +222,13 @@ class Conductor(Config):
             proj.project_name = kwargs['project_name']
         else:
             proj.project_name = os.path.basename(os.path.normpath(os.path.abspath(path)))
-        if 'version' in kwargs:
+        if 'pros-4' in kwargs:
+            if kwargs['pros-4']:
+                kwargs['version'] = '>=4.0.0'
+            else:
+                kwargs['version'] = '<4.0.0'
+            self.apply_template(proj, identifier='kernel', **kwargs)
+        elif 'version' in kwargs:
             if kwargs['version'] == 'latest':
                 kwargs['version'] = '>=0'
             self.apply_template(proj, identifier='kernel', **kwargs)


### PR DESCRIPTION
#### Summary:
Created pros-4 flag that allows choosing between PROS 4 and 3.

#### Motivation:
Since there are breaking changes between the two versions, the user should be aware of which PROS version they are installing.

##### References (optional):
Closes Issue #243

#### Test Plan:
Once PROS 4 is released, the flag can be used and the version can be checked.