### PR TITLE
✨ Added message for terminal connection

### DIFF
--- a/pros/cli/terminal.py
+++ b/pros/cli/terminal.py
@@ -109,6 +109,8 @@ def terminal(port: str, backend: str, **kwargs):
 
     signal.signal(signal.SIGINT, term.stop)
     term.start()
+    sys.stdout.write("Established terminal connection\n")
+    sys.stdout.flush()
     while not term.alive.is_set():
         time.sleep(0.005)
     sys.stdout = sys.__stdout__


### PR DESCRIPTION
#### Summary:
Includes a message indicating a successful terminal connection

#### Motivation:
It would previously display a blank screen upon connection until a program was run on the brain.

##### References (optional):
Closes Issue #249

#### Test Plan:
Use the pros terminal command (optionally with the --output flag) stdout and terminal (if they are distinct) both receive the message.
