### PR TITLE
✨ Async analytics

### DIFF
--- a/pros/cli/main.py
+++ b/pros/cli/main.py
@@ -108,12 +108,10 @@ def use_analytics(ctx: click.Context, param, value):
 @click.option('--use-analytics', help='Set analytics usage (True/False).', type=str, expose_value=False,
               is_eager=True, default=None, callback=use_analytics)
 def cli(ctx):
-    click.echo("before command")
     pros.common.sentry.register()
     ctx.call_on_close(after_command)
 
 def after_command():
-    print("after command")
     analytics.process_requests()
 
 if __name__ == '__main__':

--- a/pros/cli/main.py
+++ b/pros/cli/main.py
@@ -101,14 +101,20 @@ def use_analytics(ctx: click.Context, param, value):
 @click.command('pros',
                cls=PROSCommandCollection,
                sources=root_commands)
+@click.pass_context
 @default_options
 @click.option('--version', help='Displays version and exits.', is_flag=True, expose_value=False, is_eager=True,
               callback=version)
 @click.option('--use-analytics', help='Set analytics usage (True/False).', type=str, expose_value=False,
               is_eager=True, default=None, callback=use_analytics)
-def cli():
+def cli(ctx):
+    click.echo("before command")
     pros.common.sentry.register()
+    ctx.call_on_close(after_command)
 
+def after_command():
+    print("after command")
+    analytics.process_requests()
 
 if __name__ == '__main__':
     main()

--- a/pros/ga/analytics.py
+++ b/pros/ga/analytics.py
@@ -78,22 +78,19 @@ class Analytics():
         self.cli_config.save()
     
     def process_requests(self):
-        print("processing futures")
         responses = []
         for future in as_completed(self.pendingRequests):
             try:
                 response = future.result()
             except Exception:
-                if not response.status_code==200:
-                    print("Something went wrong while sending analytics!")
-                    print(response)
-                    responses.append(response)
-            print("response")
-            print(response)
+                print("Something went wrong while sending analytics!")
+                print(response)
+
             if not response.status_code==200:
                 print("Something went wrong while sending analytics!")
                 print(response)
-                responses.append(response)
+
+            responses.append(response)
 
         self.pendingRequests.clear()
         return responses

--- a/pros/ga/analytics.py
+++ b/pros/ga/analytics.py
@@ -60,7 +60,6 @@ class Analytics():
                              data=payload,
                              headers={'User-Agent': agent},
                              timeout=5.0)
-                             
             self.pendingRequests.append(future)
             # if not response.status_code==200:
             #     print("Something went wrong while sending analytics!")
@@ -81,15 +80,16 @@ class Analytics():
         for future in as_completed(self.pendingRequests):
             try:
                 response = future.result()
+                
+                if not response.status_code==200:
+                    print("Something went wrong while sending analytics!")
+                    print(response)
+
+                responses.append(response)
+
             except Exception:
                 print("Something went wrong while sending analytics!")
-                print(response)
 
-            if not response.status_code==200:
-                print("Something went wrong while sending analytics!")
-                print(response)
-
-            responses.append(response)
 
         self.pendingRequests.clear()
         return responses

--- a/pros/ga/analytics.py
+++ b/pros/ga/analytics.py
@@ -60,8 +60,7 @@ class Analytics():
                              data=payload,
                              headers={'User-Agent': agent},
                              timeout=5.0)
-            print("made future")
-            print(future)
+                             
             self.pendingRequests.append(future)
             # if not response.status_code==200:
             #     print("Something went wrong while sending analytics!")

--- a/pros/ga/analytics.py
+++ b/pros/ga/analytics.py
@@ -61,10 +61,7 @@ class Analytics():
                              headers={'User-Agent': agent},
                              timeout=5.0)
             self.pendingRequests.append(future)
-            # if not response.status_code==200:
-            #     print("Something went wrong while sending analytics!")
-            #     print(response)
-            # return response
+
         except Exception as e:
             from pros.cli.common import logger
             logger(__name__).warning("Unable to send analytics. Do you have a stable internet connection?", extra={'sentry': False})

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ click>=6,<7
 pyserial
 cachetools
 requests
+requests-futures
 tabulate
 jsonpickle
 semantic_version


### PR DESCRIPTION
#### Summary:
Make analytics run concurrently alongside cli commands
- Added package [`requests-futures`](https://github.com/ross/requests-futures) (an extension of `requests` - what we use right now) for handling http requests asynchronously

#### New usage:
None, but the `--use-analytics=True` flag must be set for analytics to be recorded

#### Motivation:
CLI analytics are currently a blocking function on the actual command, and can take a long time to run for those with bad internet. This change sends analytics requests in the background, so that there is no blocking.

##### References (optional):
Closes #250 

#### Test Plan:
For the following tests `--use-analytics` should be set to false
- [x] Run any command (Expected output: command runs successfully, no output because analytics aren't running)

For the following `--use-analytics` should be set to true
- [x] Run any command (Expected output: command runs successfully, analytics get sent. If there is an error with analytics, "Something went wrong while sending analytics!" is outputted)
- [x] Run a command without an Internet connection (Expected output: analytics fails, the above message is outputted)

Testing Screenshots:

No Analytics:
<img width="1148" alt="No Analytics" src="https://user-images.githubusercontent.com/43485057/213595084-0de9dc39-b727-4d37-a507-67f682da3540.png">

Successful Analytics:
<img width="1148" alt="Successful Analytics" src="https://user-images.githubusercontent.com/43485057/213595101-c27a1fa0-ed7f-494b-917e-bc82cc864258.png">

Failed Analytics:
<img width="1148" alt="Failed analytics" src="https://user-images.githubusercontent.com/43485057/213595157-25cfcda8-16f3-4128-938c-be3c976a1ad3.png">
