### PR TITLE
✨ Add error message for port not found error

### DIFF
--- a/pros/serial/ports/direct_port.py
+++ b/pros/serial/ports/direct_port.py
@@ -4,7 +4,7 @@ from typing import *
 import serial
 
 from pros.common import logger, dont_send
-from pros.serial.ports.exceptions import ConnectionRefusedException
+from pros.serial.ports.exceptions import ConnectionRefusedException, PortNotFoundException
 from .base_port import BasePort, PortConnectionException
 
 
@@ -23,7 +23,8 @@ def create_serial_port(port_name: str, timeout: Optional[float] = 1.0) -> serial
             tb = sys.exc_info()[2]
             raise dont_send(ConnectionRefusedException(port_name, e).with_traceback(tb))
         else:
-            raise e
+            raise dont_send(PortNotFoundException(port_name, e))
+
 
 
 class DirectPort(BasePort):

--- a/pros/serial/ports/exceptions.py
+++ b/pros/serial/ports/exceptions.py
@@ -1,5 +1,5 @@
 import os
-
+import serial
 
 class ConnectionRefusedException(IOError):
     def __init__(self, port_name: str, reason: Exception):
@@ -13,3 +13,18 @@ class ConnectionRefusedException(IOError):
         return f"could not open port '{self.port_name}'. Try closing any other VEX IDEs such as VEXCode, Robot Mesh Studio, or " \
             f"firmware utilities; moving to a different USB port; {extra}or " \
             f"restarting the device."
+
+class PortNotFoundException(serial.SerialException):
+    def __init__(self, port_name: str, reason: Exception):
+        self.__cause__ = reason
+        self.port_name = port_name
+
+    def __str__(self):
+        extra = ''
+        if os.name == 'posix':
+            extra = 'adding yourself to dialout group '
+        return f"Port not found: Could not open port '{self.port_name}'. Try closing any other VEX IDEs such as VEXCode, Robot Mesh Studio, or " \
+            f"firmware utilities; moving to a different USB port; {extra}or " \
+            f"restarting the device."
+
+


### PR DESCRIPTION
#### Summary:
Add proper error handling and messages for when a port argument is passed to a command and the port can't be found

#### Motivation:
As described in #262 this is a quality of life improvement. Previously, passing an invalid port would result in logging a serial.SerialException. This feature outputs a more user friendly error message.

##### References (optional):
Closes #262

#### Test Plan:
- [x] Run a command and pass an invalid port argument

#### Testing Screenshots
<img width="1157" alt="Screenshot 2023-01-26 at 8 47 29 PM" src="https://user-images.githubusercontent.com/43485057/214992431-1dbf5fef-4038-4747-9ece-b3e6c526032b.png">

