### PR TITLE
🐛 Fix macos CI universal dependency errors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
       if: matrix.os == 'macos-latest'
         
     - name: Install Requirements
-      run: python3 -m pip install --upgrade pip && pip3 install wheel && pip3 install -r requirements.txt && pip3 uninstall -y typing
+      run: python3 -m pip install --upgrade pip && pip3 install wheel && pip3 install -r requirements.txt && pip3 uninstall -y typing && pip3 uninstall -y charset_normalizer
     
     - name: Build Wheel
       run: python3 setup.py bdist_wheel


### PR DESCRIPTION
#### Summary:
Uninstalled a python dependency causing CI builds on macos to fail.

#### Motivation:
A dependency, `charset_normalizer`, not necessary for CI builds does not support universal binaries causing the CI to fail. This does not affect normal usage of the CLI as pip will install the dependency specific to the hardware (apple silicon or intel).

#### Test Plan:
Push any commit and confirm CI builds passed:
<img width="313" alt="Screenshot 2023-03-02 at 2 18 10 PM" src="https://user-images.githubusercontent.com/71904196/222529553-c6634117-9673-44ae-9b75-cda2f3a72dfe.png">
