### PR TITLE
🐛 Deprecate `pros upgrade`

### DIFF
--- a/pros/cli/misc_commands.py
+++ b/pros/cli/misc_commands.py
@@ -17,6 +17,11 @@ def upgrade(force_check, no_install):
     """
     Check for updates to the PROS CLI
     """
+    with ui.Notification():
+        ui.echo('The "pros upgrade" command is currently non-functioning. Did you mean to run "pros c upgrade"?', color='yellow')
+        
+    return # Dead code below
+    
     analytics.send("upgrade")
     from pros.upgrade import UpgradeManager
     manager = UpgradeManager()


### PR DESCRIPTION
Deprecate `pros upgrade` in favor of `pros c upgrade`

Closes #288 