### PR TITLE
:bug: Resolve Python 3.11.6_1 Enum changes

### DIFF
--- a/pros/serial/devices/vex/v5_device.py
+++ b/pros/serial/devices/vex/v5_device.py
@@ -130,7 +130,7 @@ class V5Device(VEXDevice, SystemDevice):
             BRAIN = 0x10
 
         class BrainFlags(IntFlag):
-            pass
+            CONNECTED = 0x02
 
         class ControllerFlags(IntFlag):
             CONNECTED = 0x02


### PR DESCRIPTION
#### Summary:
Python 3.11.6_1 no longer allows for empty enum classes, this addresses it.
see this: https://fossies.org/diffs/Python/3.11.5_vs_3.11.6/Lib/enum.py-diff.html. 

This is a bandaid solution for the problem of our CLI installs sometimes deciding to use user installed version of python instead of the one that comes with the CLI. Either way we should probably do this anyways since it fixes it on new python without breaking it on the older versions. (probably [?] it is currently untested).

#### Motivation:
VTOW bug report

#### Test Plan:
- [ ] Make sure uploading doesn't give weird errors on python 3.11.6_1, as well as some version older than that (3.11.5, 3.9.x, etc)
