### PR TITLE
🐛 Fix dirty version name

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,8 @@ jobs:
       - name: Update Build Number
         id: step1
         run: |
+              git describe --tags
+              git clean -f
               python3 version.py
               echo "::set-output name=test::$(cat version)"
 


### PR DESCRIPTION
#### Summary:
This PR addresses the issue of `version.py` not giving a clean version number. 

#### Motivation:
The cause is still not completely clear to me but it seems that the `git clean -f` command fixes the added characters that the "--dirty" flag will added when using git describe if there are local uncommitted changes. This was tried on master without luck but adding this command without the other changes to the workflow works with my new tag.

#### Test Plan:

- [x] Create a new tag on the latest commit, push the tag and check the artifacts have a clean version number
<img width="618" alt="Screenshot 2024-01-14 at 1 00 27 PM" src="https://github.com/purduesigbots/pros-cli/assets/71904196/a0e38e15-58bb-4557-a97c-9c8186c6f479">
<img width="1061" alt="Screenshot 2024-01-14 at 12 53 31 PM" src="https://github.com/purduesigbots/pros-cli/assets/71904196/348fb5cd-bd54-419b-8e35-94a21b2423db">

