### PR TITLE
🐛 Fix exit code click bug

### DIFF
--- a/pros/cli/conductor.py
+++ b/pros/cli/conductor.py
@@ -237,7 +237,10 @@ def new_project(ctx: click.Context, path: str, target: str, version: str,
         if compile_after or build_cache:
             with ui.Notification():
                 ui.echo('Building project...')
-                ctx.exit(project.compile([], scan_build=build_cache))
+                exit_code = project.compile([], scan_build=build_cache)
+                if exit_code != 0:
+                    logger(__name__).error(f'Failed to make project: Exit Code {exit_code}', extra={'sentry': False})
+                    raise click.ClickException('Failed to build')
 
     except Exception as e:
         pros.common.logger(__name__).exception(e)


### PR DESCRIPTION
#### Summary:
This solves the issue where click throws an error when building a new project.

#### Test Plan:
Create a new project with click 8.

<img width="962" alt="Screenshot 2024-01-18 at 8 18 58 PM" src="https://github.com/purduesigbots/pros-cli/assets/71904196/2e990f9b-a32e-4bb0-bed8-ff0db12c2b85">
