### PR TITLE
🐛 FIx CI version names

### DIFF
--- a/version.py
+++ b/version.py
@@ -4,7 +4,7 @@ from sys import stdout
 
 try:
     with open(os.devnull, 'w') as devnull:
-        v = subprocess.check_output(['git', 'describe', '--dirty', '--abbrev'], stderr=stdout).decode().strip()
+        v = subprocess.check_output(['git', 'describe', '--tags', '--dirty', '--abbrev'], stderr=stdout).decode().strip()
     if '-' in v:
         bv = v[:v.index('-')]
         bv = bv[:bv.rindex('.') + 1] + str(int(bv[bv.rindex('.') + 1:]) + 1)


### PR DESCRIPTION
#### Summary
The previous fix did not completely fix the version names (cause unknown) but this fix will provide more consistent results and works for tags on the CI.

#### Test Plan:
Create a tag and check version name outputs for tag name.
