### PR TITLE
:bug: Fix default template selection

### DIFF
--- a/pros/conductor/conductor.py
+++ b/pros/conductor/conductor.py
@@ -333,7 +333,7 @@ class Conductor(Config):
         proj.save()
 
         if not no_default_libs:
-            libraries = self.early_access_libraries if self.use_early_access else self.default_libraries
+            libraries = self.early_access_libraries if self.use_early_access and (kwargs.get("version", ">").startswith("4") or kwargs.get("version", ">").startswith(">")) else self.default_libraries
             for library in libraries[proj.target]:
                 try:
                     # remove kernel version so that latest template satisfying query is correctly selected


### PR DESCRIPTION
There was a problem when creating a PROS 3 project with beta flag enabled where it would use the early access default templates (liblvgl), but since it is a PROS 3 project it would break. This was tested a couple times and seems legit.
