### PR TITLE
🐛 Fix rich click for make compile error

### DIFF
--- a/pros/cli/build.py
+++ b/pros/cli/build.py
@@ -1,3 +1,5 @@
+import ctypes
+import sys
 from typing import *
 
 import click
@@ -24,6 +26,10 @@ def make(project: c.Project, build_args):
     analytics.send("make")
     exit_code = project.compile(build_args)
     if exit_code != 0:
+        if sys.platform == 'win32':
+            kernel32 = ctypes.windll.kernel32
+            kernel32.SetConsoleMode(kernel32.GetStdHandle(-11), 7)
+
         logger(__name__).error(f'Failed to make project: Exit Code {exit_code}', extra={'sentry': False})
         raise click.ClickException('Failed to build')
     return exit_code

--- a/pros/cli/build.py
+++ b/pros/cli/build.py
@@ -77,6 +77,10 @@ def build_compile_commands(project: c.Project, suppress_output: bool, compile_co
     exit_code = project.make_scan_build(build_args, cdb_file=compile_commands, suppress_output=suppress_output,
                                         sandbox=sandbox)
     if exit_code != 0:
+        if sys.platform == 'win32':
+            kernel32 = ctypes.windll.kernel32
+            kernel32.SetConsoleMode(kernel32.GetStdHandle(-11), 7)
+
         logger(__name__).error(f'Failed to make project: Exit Code {exit_code}', extra={'sentry': False})
         raise click.ClickException('Failed to build')
     return exit_code


### PR DESCRIPTION
#### Summary:
Overrides console mode on windows in make

#### Motivation:
There is a bug where rich formatting doesn't work in Windows due to make overriding the console mode.

#### Test Plan:

- [x] Run `pros m` on a project that has a compile error and ensure that rich formatting is applied
