### PR TITLE
🐛 Better error message for File not found on fetch

### DIFF
--- a/pros/cli/conductor.py
+++ b/pros/cli/conductor.py
@@ -64,6 +64,9 @@ def fetch(query: c.BaseTemplate):
     else:
         if template_file:
             logger(__name__).debug(f'Template file exists but is not a valid template: {template_file}')
+        else:
+            logger(__name__).error(f'Template not found: {query.name}')
+            return -1
         template = c.Conductor().resolve_template(query, allow_offline=False)
         logger(__name__).debug(f'Template from resolved query: {template}')
         if template is None:


### PR DESCRIPTION
#### Summary:
Improves the error message when a user tries to fetch a template when the file is not located

probably should look into what occurs when the file is found but is not a .zip or a template.pros, but I don't understand conductor well enough to fix that quickly
 
#### Motivation:
Current error messages don't indicate what is going on to the user. 
Example: 
`ERROR - __main__:main - 'NoneType' object has no attribute 'split' - pros-cli version:3.5.0
  File "pros/conductor/conductor.py", line 188, in resolve_template
  File "pros/conductor/conductor.py", line 174, in resolve_templates
AttributeError: 'NoneType' object has no attribute 'split'`



#### Test Plan:
<!-- Provide a list of steps that can be taken to verify these changes work as intended -->

- [x] Fetch a valid template still works
- [x] Fetching a file that doesn't exist prints the new error message. 

![image](https://github.com/purduesigbots/pros-cli/assets/50681033/743f9ac5-62ed-4ed3-9859-c00035623ff9)


