### PR TITLE
🐛 Fix aliases in pros v5

### DIFF
--- a/pros/cli/v5_utils.py
+++ b/pros/cli/v5_utils.py
@@ -291,7 +291,7 @@ def capture(file_name: str, port: str, force: bool = False):
 
     print(f'Saved screen capture to {file_name}')
 
-@v5.command(aliases=['sv', 'set'], short_help='Set a kernel variable on a connected V5 device')
+@v5.command('set-variable', aliases=['sv', 'set'], short_help='Set a kernel variable on a connected V5 device')
 @click.argument('variable', type=click.Choice(['teamnumber', 'robotname']), required=True)
 @click.argument('value', required=True, type=click.STRING, nargs=1)
 @click.argument('port', type=str, default=None, required=False)
@@ -308,7 +308,7 @@ def set_variable(variable, value, port):
     actual_value = device.kv_write(variable, value).decode()
     print(f'Value of \'{variable}\' set to : {actual_value}')
 
-@v5.command(aliases=['rv', 'get'], short_help='Read a kernel variable from a connected V5 device')
+@v5.command('read-variable', aliases=['rv', 'get'], short_help='Read a kernel variable from a connected V5 device')
 @click.argument('variable', type=click.Choice(['teamnumber', 'robotname']), required=True)
 @click.argument('port', type=str, default=None, required=False)
 @default_options

--- a/pros/cli/v5_utils.py
+++ b/pros/cli/v5_utils.py
@@ -291,7 +291,7 @@ def capture(file_name: str, port: str, force: bool = False):
 
     print(f'Saved screen capture to {file_name}')
 
-@v5.command('set-variable', aliases=['sv', 'set'], short_help='Set a kernel variable on a connected V5 device')
+@v5.command('set-variable', aliases=['sv', 'set', 'set_variable'], short_help='Set a kernel variable on a connected V5 device')
 @click.argument('variable', type=click.Choice(['teamnumber', 'robotname']), required=True)
 @click.argument('value', required=True, type=click.STRING, nargs=1)
 @click.argument('port', type=str, default=None, required=False)
@@ -308,7 +308,7 @@ def set_variable(variable, value, port):
     actual_value = device.kv_write(variable, value).decode()
     print(f'Value of \'{variable}\' set to : {actual_value}')
 
-@v5.command('read-variable', aliases=['rv', 'get'], short_help='Read a kernel variable from a connected V5 device')
+@v5.command('read-variable', aliases=['rv', 'get', 'read_variable'], short_help='Read a kernel variable from a connected V5 device')
 @click.argument('variable', type=click.Choice(['teamnumber', 'robotname']), required=True)
 @click.argument('port', type=str, default=None, required=False)
 @default_options


### PR DESCRIPTION
#### Summary:
`pros v5 set-variable` and `pros v5 read-variable` are explicitly named and `pros v5 set_variable` and `pros v5 read_variable` are added as aliases.

#### Motivation:
The aliases for `pros v5 set-variable` and `pros v5 read-variable` are not working. #307 upgraded click which converts underscores in command names to dashes.

#### Test Plan:
- [x] `pros v5 set-variable`
- [x] `pros v5 set_variable`
- [x] `pros v5 sv`
- [x] `pros v5 set`
- [x] `pros v5 read-variable`
- [x] `pros v5 read_variable`
- [x] `pros v5 rv`
- [x] `pros v5 get`
