### PR TITLE
🚸 Disable sentry confirmation prompt

### DIFF
--- a/pros/cli/common.py
+++ b/pros/cli/common.py
@@ -124,7 +124,7 @@ def no_sentry_option(f: Union[click.Command, Callable]):
         add_tag('no-sentry',value)
         if value:
             pros.common.sentry.disable_prompt()
-    decorator = click.option('--no-sentry', expose_value=False, is_flag=True, default=False, is_eager=True,
+    decorator = click.option('--no-sentry', expose_value=False, is_flag=True, default=True, is_eager=True,
                             help="Disable sentry reporting prompt.", callback=callback, cls=PROSOption, hidden=True)(f)
     decorator.__name__ = f.__name__
     return decorator


### PR DESCRIPTION
#### Summary:
Disables sentry reporting confirmation prompt

#### Motivation:
The data collected by sentry is not very useful

#### Test Plan:
- [x] Run any command with a Python error and ensure that the sentry reporting confirmation doesn't show
