### PR TITLE
🚸 Add single letter `query-templates` alias

### DIFF
--- a/pros/cli/conductor.py
+++ b/pros/cli/conductor.py
@@ -251,7 +251,7 @@ def new_project(ctx: click.Context, path: str, target: str, version: str,
 
 
 @conductor.command('query-templates',
-                   aliases=['search-templates', 'ls-templates', 'lstemplates', 'querytemplates', 'searchtemplates'],
+                   aliases=['search-templates', 'ls-templates', 'lstemplates', 'querytemplates', 'searchtemplates', 'q'],
                    context_settings={'ignore_unknown_options': True})
 @click.option('--allow-offline/--no-offline', 'allow_offline', default=True, show_default=True,
               help='(Dis)allow offline templates in the listing')


### PR DESCRIPTION
#### Summary:
Add an alias for `query-templates`.

#### Motivation:
QOL

#### Test Plan:
Run `pros c q`. You should see `query-templates` running.

<img width="1018" alt="Screenshot 2024-02-16 at 2 43 55 PM" src="https://github.com/purduesigbots/pros-cli/assets/71904196/5276a8cb-b125-495f-91e3-02aa4e6bd37e">
