### PR TITLE
ci: :technologist: Upload dist/pros/*

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,3 @@
-# test
 name: Build PROS CLI
 
 on:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,4 +93,4 @@ jobs:
       uses: actions/upload-artifact@v3.1.0
       with:
         name: ${{ matrix.os }}-${{needs.update_build_number.outputs.output1}}
-        path: dist/*
+        path: dist/pros/*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,3 +1,4 @@
+# test
 name: Build PROS CLI
 
 on:


### PR DESCRIPTION
#### Summary:
<!-- Provide a concise description of your changes -->
Upload `dist/pros/*` instead of `dist/*`, which removes the extra pros directory:
```
.
└── pros
    ├── _internal
    ├── intercept-c++.exe
    ├── intercept-cc.exe
    └── pros.exe
```
->
```
.
├── _internal
├── intercept-c++.exe
├── intercept-cc.exe
└── pros.exe
```
#### Motivation:
<!-- Provide a brief description of why you think these changes need to be made -->
Uploading the extra pros directory adds another potential point of failure when creating releases that can be easily mitigated by removing it.
##### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->
- [vtow help post](https://discord.com/channels/197777408198180864/1220548376047910993)
#### Test Plan:
<!-- Provide a list of steps that can be taken to verify these changes work as intended -->

- the artifacts [here](https://github.com/meisZWFLZ/pros-cli/actions/runs/8384604763) no longer have an extra pros directory

#### Additional Notes
- It does remove the python wheel thing from the ubuntu artifact, so I hope that's not necessary

# **Squash merge please**
dont want those test commits clogging up the commit history