### PR TITLE
✨ Setup Autocomplete

### DIFF
--- a/pros/autocomplete/.pros-complete.bash
+++ b/pros/autocomplete/.pros-complete.bash
@@ -1,3 +1,4 @@
+[[ ${BASH_VERSINFO[0]} -ge 4 ]] || return 0
 _pros_completion() {
   local IFS=$'\n'
   local response

--- a/pros/autocomplete/.pros-complete.bash
+++ b/pros/autocomplete/.pros-complete.bash
@@ -1,4 +1,3 @@
-[[ ${BASH_VERSINFO[0]} -ge 4 ]] || return 0
 _pros_completion() {
   local IFS=$'\n'
   local response
@@ -18,6 +17,10 @@ _pros_completion() {
   return 0
 }
 _pros_completion_setup() {
-  complete -o nosort -F _pros_completion pros
+  if [[ ${BASH_VERSINFO[0]} -ge 4 ]]; then
+    complete -o nosort -F _pros_completion pros
+  else
+    complete -F _pros_completion pros
+  fi
 }
 _pros_completion_setup

--- a/pros/autocomplete/.pros-complete.bash
+++ b/pros/autocomplete/.pros-complete.bash
@@ -1,0 +1,22 @@
+_pros_completion() {
+  local IFS=$'\n'
+  local response
+  response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _PROS_COMPLETE=bash_complete $1)
+  for completion in $response; do
+    IFS=',' read type value <<<"$completion"
+    if [[ $type == 'dir' ]]; then
+      COMPREPLY=()
+      compopt -o dirnames
+    elif [[ $type == 'file' ]]; then
+      COMPREPLY=()
+      compopt -o default
+    elif [[ $type == 'plain' ]]; then
+      COMPREPLY+=($value)
+    fi
+  done
+  return 0
+}
+_pros_completion_setup() {
+  complete -o nosort -F _pros_completion pros
+}
+_pros_completion_setup

--- a/pros/autocomplete/.pros-complete.zsh
+++ b/pros/autocomplete/.pros-complete.zsh
@@ -1,0 +1,31 @@
+_pros_completion() {
+  local -a completions
+  local -a completions_with_descriptions
+  local -a response
+  (( ! $+commands[pros] )) && return 1
+  response=("${(@f)$(env COMP_WORDS="${words[*]}" COMP_CWORD=$((CURRENT-1)) _PROS_COMPLETE=zsh_complete pros)}")
+  for type key descr in ${response}; do
+    if [[ "$type" == "plain" ]]; then
+      if [[ "$descr" == "_" ]]; then
+        completions+=("$key")
+      else
+        completions_with_descriptions+=("$key":"$descr")
+      fi
+    elif [[ "$type" == "dir" ]]; then
+      _path_files -/
+    elif [[ "$type" == "file" ]]; then
+      _path_files -f
+    fi
+  done
+  if [ -n "$completions_with_descriptions" ]; then
+    _describe -V unsorted completions_with_descriptions -U
+  fi
+  if [ -n "$completions" ]; then
+    compadd -U -V unsorted -a completions
+  fi
+}
+if [[ $zsh_eval_context[-1] == loadautofunc ]]; then
+  _pros_completion "$@"
+else
+  compdef _pros_completion pros
+fi

--- a/pros/autocomplete/pros-complete.ps1
+++ b/pros/autocomplete/pros-complete.ps1
@@ -1,0 +1,45 @@
+# Modified from https://github.com/StephLin/click-pwsh/blob/main/click_pwsh/shell_completion.py#L11
+Register-ArgumentCompleter -Native -CommandName pros -ScriptBlock {
+  param($wordToComplete, $commandAst, $cursorPosition)
+  $env:COMP_WORDS = $commandAst
+  $env:COMP_WORDS = $env:COMP_WORDS.replace('\\', '/')
+  $incompleteCommand = $commandAst.ToString()
+  $myCursorPosition = $cursorPosition
+  if ($myCursorPosition -gt $incompleteCommand.Length) {
+    $myCursorPosition = $incompleteCommand.Length
+  }
+  $env:COMP_CWORD = @($incompleteCommand.substring(0, $myCursorPosition).Split(" ") | Where-Object { $_ -ne "" }).Length
+  if ( $wordToComplete.Length -gt 0) { $env:COMP_CWORD -= 1 }
+  $env:_PROS_COMPLETE = "powershell_complete"
+  pros | ForEach-Object {
+    $type, $value, $help = $_.Split(",", 3)
+    if ( ($type -eq "plain") -and ![string]::IsNullOrEmpty($value) ) {
+      [System.Management.Automation.CompletionResult]::new($value, $value, "ParameterValue", $value)
+    }
+    elseif ( ($type -eq "file") -or ($type -eq "dir") ) {
+      if ([string]::IsNullOrEmpty($wordToComplete)) {
+        $dir = "./"
+      }
+      else {
+        $dir = $wordToComplete.replace('\\', '/')
+      }
+      if ( (Test-Path -Path $dir) -and ((Get-Item $dir) -is [System.IO.DirectoryInfo]) ) {
+        [System.Management.Automation.CompletionResult]::new($dir, $dir, "ParameterValue", $dir)
+      }
+      Get-ChildItem -Path $dir | Resolve-Path -Relative | ForEach-Object {
+        $path = $_.ToString().replace('\\', '/').replace('Microsoft.PowerShell.Core/FileSystem::', '')
+        $isDir = $false
+        if ((Get-Item $path) -is [System.IO.DirectoryInfo]) {
+          $path = $path + "/"
+          $isDir = $true
+        }
+        if ( ($type -eq "file") -or ( ($type -eq "dir") -and $isDir ) ) {
+          [System.Management.Automation.CompletionResult]::new($path, $path, "ParameterValue", $path)
+        }
+      }
+    }
+  }
+  $env:COMP_WORDS = $null | Out-Null
+  $env:COMP_CWORD = $null | Out-Null
+  $env:_PROS_COMPLETE = $null | Out-Null
+}

--- a/pros/autocomplete/pros.fish
+++ b/pros/autocomplete/pros.fish
@@ -1,0 +1,14 @@
+function _pros_completion;
+  set -l response (env _PROS_COMPLETE=fish_complete COMP_WORDS=(commandline -cp) COMP_CWORD=(commandline -t) pros);
+  for completion in $response;
+    set -l metadata (string split "," $completion);
+    if test $metadata[1] = "dir";
+      __fish_complete_directories $metadata[2];
+    else if test $metadata[1] = "file";
+      __fish_complete_path $metadata[2];
+    else if test $metadata[1] = "plain";
+      echo $metadata[2];
+    end;
+  end;
+end;
+complete --no-files --command pros --arguments "(_pros_completion)";

--- a/pros/cli/misc_commands.py
+++ b/pros/cli/misc_commands.py
@@ -137,7 +137,7 @@ def setup_autocomplete(shell, config_file, force):
 
     if shell in ('pwsh', 'powershell') and config_file is None:
         try:
-            profile_command = f'{shell} -c "echo $PROFILE"' if os.name == 'nt' else f"{shell} -c 'echo $PROFILE'"
+            profile_command = f'{shell} -NoLogo -NoProfile -Command "Write-Output $PROFILE"' if os.name == 'nt' else f"{shell} -NoLogo -NoProfile -Command 'Write-Output $PROFILE'"
             default_config_files[shell] = subprocess.run(profile_command, shell=True, capture_output=True, check=True).stdout.decode().strip()
         except subprocess.CalledProcessError as exc:
             raise click.UsageError("Failed to determine the PowerShell profile path. Please specify a valid config file.") from exc
@@ -192,7 +192,7 @@ def setup_autocomplete(shell, config_file, force):
             raise click.UsageError(f"Config directory {config_dir} does not exist. Please specify a valid config file.")
 
         # Write the autocomplete script to a PowerShell script file
-        script_file = os.path.join(os.path.dirname(config_file), "pros-complete.ps1")
+        script_file = os.path.join(config_dir, "pros-complete.ps1")
         with open(script_file, 'w') as f:
             f.write(_SOURCE_POWERSHELL)
 

--- a/pros/cli/misc_commands.py
+++ b/pros/cli/misc_commands.py
@@ -93,6 +93,9 @@ def setup_autocomplete(shell, config_file):
                 f.write("\n# PROS CLI autocomplete\n")
                 f.write(source_autocomplete)
     elif shell == 'fish':
+        config_dir = os.path.dirname(config_file)
+        if not os.path.exists(config_dir):
+            raise click.UsageError(f"Config directory {config_dir} does not exist. Please specify a valid config file.")
         with open(config_file, 'w') as f:
             if subprocess.Popen(f"_PROS_COMPLETE={shell}_source pros", shell=True, stdout=f).wait():
                 raise click.ClickException(f"Failed to write autocomplete script to {config_file}")

--- a/pros/cli/misc_commands.py
+++ b/pros/cli/misc_commands.py
@@ -71,7 +71,7 @@ def setup_autocomplete(shell, config_file):
         config_file = default_config_files[shell]
     config_file = os.path.expanduser(config_file)
 
-    if shell in ['bash', 'zsh']:
+    if shell in ('bash', 'zsh'):
         if not os.path.exists(config_file):
             raise click.UsageError(f"Config file {config_file} does not exist. Please specify a valid config file.")
 
@@ -87,21 +87,26 @@ def setup_autocomplete(shell, config_file):
             except subprocess.CalledProcessError as exc:
                 raise click.ClickException(f"Failed to write autocomplete script to {script_file}") from exc
 
-        # Source the autocomplete script in the config file
-        source_autocomplete = f". ~/.pros-complete.{shell}\n"
-        with open(config_file, 'r+') as f:
-            # Only append if the source command is not already in the file
-            if source_autocomplete not in f.readlines():
-                f.write("\n# PROS CLI autocomplete\n")
-                f.write(source_autocomplete)
+        source_autocomplete = f". {script_file}\n"
+        if ui.confirm(f"Add the autocomplete script to {config_file}?", default=True):
+            # Source the autocomplete script in the config file
+            with open(config_file, 'r+') as f:
+                # Only append if the source command is not already in the file
+                if source_autocomplete not in f.readlines():
+                    f.write("\n# PROS CLI autocomplete\n")
+                    f.write(source_autocomplete)
+        else:
+            ui.echo(f"Autocomplete script written to {script_file}. Add the following line to {config_file} then restart your shell to enable autocomplete:")
+            ui.echo(source_autocomplete)
+            return
     elif shell == 'fish':
         config_dir = os.path.dirname(config_file)
         if not os.path.exists(config_dir):
-            raise click.UsageError(f"Config directory {config_dir} does not exist. Please specify a valid config file.")
+            raise click.UsageError(f"Completions directory {config_dir} does not exist. Please specify a valid completion file.")
         with open(config_file, 'w') as f:
             try:
                 subprocess.run(f"_PROS_COMPLETE={shell}_source pros", shell=True, stdout=f, check=True)
             except subprocess.CalledProcessError as exc:
                 raise click.ClickException(f"Failed to write autocomplete script to {config_file}") from exc
 
-    ui.echo(f"Succesfully set up autocomplete for PROS CLI for {shell} in {config_file}. Restart your shell to apply changes.")
+    ui.echo(f"Succesfully set up autocomplete for {shell} in {config_file}. Restart your shell to apply changes.")

--- a/pros/cli/misc_commands.py
+++ b/pros/cli/misc_commands.py
@@ -183,6 +183,13 @@ def setup_autocomplete(shell, config_file):
             except subprocess.CalledProcessError as exc:
                 raise click.ClickException(f"Failed to write autocomplete script to {config_file}") from exc
     elif shell in ('pwsh', 'powershell'):
+        if not os.path.exists(config_file):
+            raise click.UsageError(f"Config file {config_file} does not exist. Please specify a valid config file.")
+
+        config_dir = os.path.dirname(config_file)
+        if not os.path.exists(config_dir):
+            raise click.UsageError(f"Config directory {config_dir} does not exist. Please specify a valid config file.")
+
         # Write the autocomplete script to a PowerShell script file
         script_file = os.path.join(os.path.dirname(config_file), "pros-complete.ps1")
         with open(script_file, 'w') as f:

--- a/pros/cli/misc_commands.py
+++ b/pros/cli/misc_commands.py
@@ -109,7 +109,7 @@ def setup_autocomplete(shell, config_file, force):
     if config_file is None:
         config_file = default_config_files[shell]
         ui.echo(f"Using default config file {config_file}. To specify a different config file, run 'pros setup-autocomplete {shell} CONFIG_FILE'.\n")
-    config_file = Path(config_file).resolve()
+    config_file = Path(config_file).expanduser().resolve()
 
     if shell in ('bash', 'zsh', 'pwsh', 'powershell'):
         if config_file.is_dir():

--- a/pros/cli/misc_commands.py
+++ b/pros/cli/misc_commands.py
@@ -58,7 +58,7 @@ _SCRIPT_FILES = {
 
 
 def _get_shell_script(shell: str) -> str:
-    script_file = Path(__file__).parent / '..' / 'autocomplete' / _SCRIPT_FILES[shell]
+    script_file = Path(__file__).parent.parent / 'autocomplete' / _SCRIPT_FILES[shell]
     with script_file.open('r') as f:
         return f.read()
 
@@ -76,22 +76,24 @@ class PowerShellComplete(ZshComplete):
 
 @misc_commands_cli.command()
 @click.argument('shell', type=click.Choice(['bash', 'zsh', 'fish', 'pwsh', 'powershell']), required=True)
-@click.argument('config_file', type=click.Path(file_okay=True, dir_okay=True), default=None, required=False)
+@click.argument('config_path', type=click.Path(resolve_path=True), default=None, required=False)
 @click.option('--force', '-f', is_flag=True, default=False, help='Skip confirmation prompts')
 @default_options
-def setup_autocomplete(shell, config_file, force):
+def setup_autocomplete(shell, config_path, force):
     """
     Set up autocomplete for PROS CLI in the specified shell
 
     SHELL: The shell to set up autocomplete for
 
-    CONFIG_FILE: The configuration file to add the autocomplete script to. If not specified, the default configuration
+    CONFIG_PATH: The configuration path to add the autocomplete script to. If not specified, the default configuration
     file for the shell will be used.
+
+    Example: pros setup-autocomplete bash ~/.bashrc
     """
 
     # https://click.palletsprojects.com/en/8.1.x/shell-completion/
 
-    default_config_files = {
+    default_config_paths = {
         'bash': '~/.bashrc',
         'zsh': '~/.zshrc',
         'fish': '~/.config/fish/completions/',
@@ -99,57 +101,58 @@ def setup_autocomplete(shell, config_file, force):
         'powershell': None,
     }
 
-    if shell in ('pwsh', 'powershell') and config_file is None:
+    if shell in ('pwsh', 'powershell') and config_path is None:
         try:
             profile_command = f'{shell} -NoLogo -NoProfile -Command "Write-Output $PROFILE"' if os.name == 'nt' else f"{shell} -NoLogo -NoProfile -Command 'Write-Output $PROFILE'"
-            default_config_files[shell] = subprocess.run(profile_command, shell=True, capture_output=True, check=True).stdout.decode().strip()
+            default_config_paths[shell] = subprocess.run(profile_command, shell=True, capture_output=True, check=True).stdout.decode().strip()
         except subprocess.CalledProcessError as exc:
             raise click.UsageError("Failed to determine the PowerShell profile path. Please specify a valid config file.") from exc
 
-    if config_file is None:
-        config_file = default_config_files[shell]
-        ui.echo(f"Using default config file {config_file}. To specify a different config file, run 'pros setup-autocomplete {shell} CONFIG_FILE'.\n")
-    config_file = Path(config_file).expanduser().resolve()
+    if config_path is None:
+        config_path = default_config_paths[shell]
+        ui.echo(f"Using default config path {config_path}. To specify a different config path, run 'pros setup-autocomplete {shell} [CONFIG_PATH]'.\n")
+    config_path = Path(config_path).expanduser().resolve()
 
     if shell in ('bash', 'zsh', 'pwsh', 'powershell'):
-        if config_file.is_dir():
-            raise click.UsageError(f"Config file {config_file} is a directory. Please specify a valid config file.")
-        if not config_file.exists():
-            raise click.UsageError(f"Config file {config_file} does not exist. Please specify a valid config file.")
+        if config_path.is_dir():
+            raise click.UsageError(f"Config file {config_path} is a directory. Please specify a valid config file.")
+        if not config_path.exists():
+            raise click.UsageError(f"Config file {config_path} does not exist. Please specify a valid config file.")
 
         # Write the autocomplete script to a shell script file
-        script_file = config_file.parent / _SCRIPT_FILES[shell]
-        with open(script_file, 'w') as f:
+        script_file = config_path.parent / _SCRIPT_FILES[shell]
+        with script_file.open('w') as f:
             f.write(_get_shell_script(shell))
 
         if shell in ('bash', 'zsh'):
             source_autocomplete = f". {script_file.as_posix()}\n"
         elif shell in ('pwsh', 'powershell'):
             source_autocomplete = f"{script_file} | Invoke-Expression\n"
-        if force or ui.confirm(f"Add the autocomplete script to {config_file}?", default=True):
+        if force or ui.confirm(f"Add the autocomplete script to {config_path}?", default=True):
             # Source the autocomplete script in the config file
-            with open(config_file, 'r+') as f:
+            with config_path.open('r+') as f:
                 # Only append if the source command is not already in the file
                 if source_autocomplete not in f.readlines():
                     f.write("\n# PROS CLI autocomplete\n")
                     f.write(source_autocomplete)
         else:
-            ui.echo(f"Autocomplete script written to {script_file}. Add the following line to {config_file} then restart your shell to enable autocomplete:\n")
+            ui.echo(f"Autocomplete script written to {script_file}.")
+            ui.echo(f"Add the following line to {config_path} then restart your shell to enable autocomplete:\n")
             ui.echo(source_autocomplete)
             return
     elif shell == 'fish':
-        if config_file.is_file():
-            script_dir = config_file.parent
-            script_file = config_file
+        if config_path.is_file():
+            script_dir = config_path.parent
+            script_file = config_path
         else:
-            script_dir = config_file
-            script_file = config_file / _SCRIPT_FILES[shell]
+            script_dir = config_path
+            script_file = config_path / _SCRIPT_FILES[shell]
 
         if not script_dir.exists():
             raise click.UsageError(f"Completions directory {script_dir} does not exist. Please specify a valid completions file or directory.")
 
         # Write the autocomplete script to a shell script file
-        with open(script_file, 'w') as f:
+        with script_file.open('w') as f:
             f.write(_get_shell_script(shell))
 
-    ui.echo(f"Succesfully set up autocomplete for {shell} in {config_file}. Restart your shell to apply changes.")
+    ui.echo(f"Succesfully set up autocomplete for {shell} in {config_path}. Restart your shell to apply changes.")

--- a/pros/cli/misc_commands.py
+++ b/pros/cli/misc_commands.py
@@ -137,7 +137,8 @@ def setup_autocomplete(shell, config_file):
 
     if shell in ('pwsh', 'powershell') and config_file is None:
         try:
-            default_config_files[shell] = subprocess.run(f'{shell} -c "echo $profile"', capture_output=True, check=True).stdout.decode().strip()
+            profile_command = f'{shell} -c "echo $profile"' if os.name == 'nt' else f"{shell} -c 'echo $PROFILE'"
+            default_config_files[shell] = subprocess.run(profile_command, capture_output=True, check=True).stdout.decode().strip()
         except subprocess.CalledProcessError as exc:
             raise click.UsageError("Failed to determine the PowerShell profile path. Please specify a valid config file.") from exc
 

--- a/pros/cli/misc_commands.py
+++ b/pros/cli/misc_commands.py
@@ -82,8 +82,10 @@ def setup_autocomplete(shell, config_file):
         # Write the autocomplete script to a shell script file
         script_file = os.path.join(config_dir, f".pros-complete.{shell}")
         with open(script_file, 'w') as f:
-            if subprocess.Popen(f"_PROS_COMPLETE={shell}_source pros", shell=True, stdout=f).wait():
-                raise click.ClickException(f"Failed to write autocomplete script to {script_file}")
+            try:
+                subprocess.run(f"_PROS_COMPLETE={shell}_source pros", shell=True, stdout=f, check=True)
+            except subprocess.CalledProcessError as exc:
+                raise click.ClickException(f"Failed to write autocomplete script to {script_file}") from exc
 
         # Source the autocomplete script in the config file
         source_autocomplete = f". ~/.pros-complete.{shell}\n"
@@ -97,7 +99,9 @@ def setup_autocomplete(shell, config_file):
         if not os.path.exists(config_dir):
             raise click.UsageError(f"Config directory {config_dir} does not exist. Please specify a valid config file.")
         with open(config_file, 'w') as f:
-            if subprocess.Popen(f"_PROS_COMPLETE={shell}_source pros", shell=True, stdout=f).wait():
-                raise click.ClickException(f"Failed to write autocomplete script to {config_file}")
+            try:
+                subprocess.run(f"_PROS_COMPLETE={shell}_source pros", shell=True, stdout=f, check=True)
+            except subprocess.CalledProcessError as exc:
+                raise click.ClickException(f"Failed to write autocomplete script to {config_file}") from exc
 
-    ui.echo(f"Succesfully set up autocomplete for PROS CLI for {shell} in {config_file}")
+    ui.echo(f"Succesfully set up autocomplete for PROS CLI for {shell} in {config_file}. Restart your shell to apply changes.")

--- a/pros/cli/misc_commands.py
+++ b/pros/cli/misc_commands.py
@@ -126,9 +126,9 @@ def setup_autocomplete(shell, config_path, force):
             f.write(_get_shell_script(shell))
 
         if shell in ('bash', 'zsh'):
-            source_autocomplete = f". {script_file.as_posix()}\n"
+            source_autocomplete = f'. "{script_file.as_posix()}"\n'
         elif shell in ('pwsh', 'powershell'):
-            source_autocomplete = f"{script_file} | Invoke-Expression\n"
+            source_autocomplete = f'"{script_file}" | Invoke-Expression\n'
         if force or ui.confirm(f"Add the autocomplete script to {config_path}?", default=True):
             # Source the autocomplete script in the config file
             with config_path.open('r+') as f:

--- a/pros/cli/misc_commands.py
+++ b/pros/cli/misc_commands.py
@@ -50,7 +50,16 @@ def upgrade(force_check, no_install):
 @click.argument('config_file', type=click.Path(file_okay=True, dir_okay=False), default=None, required=False)
 @default_options
 def setup_autocomplete(shell, config_file):
-    ui.echo(f"Setting up autocomplete for PROS CLI for {shell} shell in {config_file}...")
+    """
+    Set up autocomplete for PROS CLI in the specified shell
+
+    SHELL: The shell to set up autocomplete for
+
+    CONFIG_FILE: The configuration file to add the autocomplete script to. If not specified, the default configuration
+    file for the shell will be used.
+    """
+
+    # https://click.palletsprojects.com/en/8.1.x/shell-completion/
 
     default_config_files = {
         'bash': '~/.bashrc',
@@ -70,17 +79,20 @@ def setup_autocomplete(shell, config_file):
         if not os.path.exists(config_dir):
             raise click.UsageError(f"Config directory {config_dir} does not exist. Please specify a valid config file.")
 
+        # Write the autocomplete script to a shell script file
         script_file = os.path.join(config_dir, f".pros-complete.{shell}")
         with open(script_file, 'w') as f:
             subprocess.Popen(f"_PROS_COMPLETE={shell}_source pros", shell=True, stdout=f).wait()
 
+        # Source the autocomplete script in the config file
         source_autocomplete = f". ~/.pros-complete.{shell}\n"
         with open(config_file, 'r+') as f:
+            # Only append if the source command is not already in the file
             if source_autocomplete not in f.readlines():
                 f.write("\n# PROS CLI autocomplete\n")
                 f.write(source_autocomplete)
-
-
-    if shell == 'fish':
+    elif shell == 'fish':
         with open(config_file, 'w') as f:
             subprocess.Popen(f"_PROS_COMPLETE={shell}_source pros", shell=True, stdout=f).wait()
+
+    ui.echo(f"Succesfully set up autocomplete for PROS CLI for {shell} in {config_file}")

--- a/pros/cli/misc_commands.py
+++ b/pros/cli/misc_commands.py
@@ -104,7 +104,7 @@ def setup_autocomplete(shell, config_path, force):
     if shell in ('pwsh', 'powershell') and config_path is None:
         try:
             profile_command = f'{shell} -NoLogo -NoProfile -Command "Write-Output $PROFILE"' if os.name == 'nt' else f"{shell} -NoLogo -NoProfile -Command 'Write-Output $PROFILE'"
-            default_config_paths[shell] = subprocess.run(profile_command, shell=True, capture_output=True, check=True).stdout.decode().strip()
+            default_config_paths[shell] = subprocess.run(profile_command, shell=True, capture_output=True, check=True, text=True).stdout.strip()
         except subprocess.CalledProcessError as exc:
             raise click.UsageError("Failed to determine the PowerShell profile path. Please specify a valid config file.") from exc
 

--- a/pros/cli/misc_commands.py
+++ b/pros/cli/misc_commands.py
@@ -81,7 +81,7 @@ class PowerShellComplete(ZshComplete):
 @default_options
 def setup_autocomplete(shell, config_path, force):
     """
-    Set up autocomplete for PROS CLI in the specified shell
+    Set up autocomplete for PROS CLI
 
     SHELL: The shell to set up autocomplete for
 

--- a/pros/cli/misc_commands.py
+++ b/pros/cli/misc_commands.py
@@ -47,125 +47,18 @@ def upgrade(force_check, no_install):
             ui.finalize('upgradeComplete', manager.perform_upgrade())
 
 
-_SOURCE_BASH = r"""_pros_completion() {
-    local IFS=$'\n'
-    local response
-    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _PROS_COMPLETE=bash_complete $1)
-    for completion in $response; do
-        IFS=',' read type value <<< "$completion"
-        if [[ $type == 'dir' ]]; then
-            COMPREPLY=()
-            compopt -o dirnames
-        elif [[ $type == 'file' ]]; then
-            COMPREPLY=()
-            compopt -o default
-        elif [[ $type == 'plain' ]]; then
-            COMPREPLY+=($value)
-        fi
-    done
-    return 0
+_SCRIPT_FILES = {
+    'bash': '.pros-complete.bash',
+    'zsh': '.pros-complete.zsh',
+    'fish': 'pros.fish',
+    'pwsh': 'pros-complete.ps1',
+    'powershell': 'pros-complete.ps1',
 }
-_pros_completion_setup() {
-    complete -o nosort -F _pros_completion pros
-}
-_pros_completion_setup;
-"""
 
-_SOURCE_ZSH = r"""_pros_completion() {
-    local -a completions
-    local -a completions_with_descriptions
-    local -a response
-    (( ! $+commands[pros] )) && return 1
-    response=("${(@f)$(env COMP_WORDS="${words[*]}" COMP_CWORD=$((CURRENT-1)) _PROS_COMPLETE=zsh_complete pros)}")
-    for type key descr in ${response}; do
-        if [[ "$type" == "plain" ]]; then
-            if [[ "$descr" == "_" ]]; then
-                completions+=("$key")
-            else
-                completions_with_descriptions+=("$key":"$descr")
-            fi
-        elif [[ "$type" == "dir" ]]; then
-            _path_files -/
-        elif [[ "$type" == "file" ]]; then
-            _path_files -f
-        fi
-    done
-    if [ -n "$completions_with_descriptions" ]; then
-        _describe -V unsorted completions_with_descriptions -U
-    fi
-    if [ -n "$completions" ]; then
-        compadd -U -V unsorted -a completions
-    fi
-}
-if [[ $zsh_eval_context[-1] == loadautofunc ]]; then
-    _pros_completion "$@"
-else
-    compdef _pros_completion pros
-fi
-"""
 
-_SOURCE_FISH = r"""function _pros_completion;
-    set -l response (env _PROS_COMPLETE=fish_complete COMP_WORDS=(commandline -cp) COMP_CWORD=(commandline -t) pros);
-    for completion in $response;
-        set -l metadata (string split "," $completion);
-        if test $metadata[1] = "dir";
-            __fish_complete_directories $metadata[2];
-        else if test $metadata[1] = "file";
-            __fish_complete_path $metadata[2];
-        else if test $metadata[1] = "plain";
-            echo $metadata[2];
-        end;
-    end;
-end;
-complete --no-files --command pros --arguments "(_pros_completion)";
-"""
-
-# Modified from https://github.com/StephLin/click-pwsh/blob/main/click_pwsh/shell_completion.py#L11
-_SOURCE_POWERSHELL = r"""Register-ArgumentCompleter -Native -CommandName pros -ScriptBlock {
-    param($wordToComplete, $commandAst, $cursorPosition)
-    $env:COMP_WORDS = $commandAst
-    $env:COMP_WORDS = $env:COMP_WORDS.replace('\\', '/')
-    $incompleteCommand = $commandAst.ToString()
-    $myCursorPosition = $cursorPosition
-    if ($myCursorPosition -gt $incompleteCommand.Length) {
-        $myCursorPosition = $incompleteCommand.Length
-    }
-    $env:COMP_CWORD = @($incompleteCommand.substring(0, $myCursorPosition).Split(" ") | Where-Object { $_ -ne "" }).Length
-    if ( $wordToComplete.Length -gt 0) { $env:COMP_CWORD -= 1 }
-    $env:_PROS_COMPLETE = "powershell_complete"
-    pros | ForEach-Object {
-        $type, $value, $help = $_.Split(",", 3)
-        if ( ($type -eq "plain") -and ![string]::IsNullOrEmpty($value) ) {
-            [System.Management.Automation.CompletionResult]::new($value, $value, "ParameterValue", $value)
-        }
-        elseif ( ($type -eq "file") -or ($type -eq "dir") ) {
-            if ([string]::IsNullOrEmpty($wordToComplete)) {
-                $dir = "./"
-            }
-            else {
-                $dir = $wordToComplete.replace('\\', '/')
-            }
-            if ( (Test-Path -Path $dir) -and ((Get-Item $dir) -is [System.IO.DirectoryInfo]) ) {
-                [System.Management.Automation.CompletionResult]::new($dir, $dir, "ParameterValue", $dir)
-            }
-            Get-ChildItem -Path $dir | Resolve-Path -Relative | ForEach-Object {
-                $path = $_.ToString().replace('\\', '/').replace('Microsoft.PowerShell.Core/FileSystem::', '')
-                $isDir = $false
-                if ((Get-Item $path) -is [System.IO.DirectoryInfo]) {
-                    $path = $path + "/"
-                    $isDir = $true
-                }
-                if ( ($type -eq "file") -or ( ($type -eq "dir") -and $isDir ) ) {
-                    [System.Management.Automation.CompletionResult]::new($path, $path, "ParameterValue", $path)
-                }
-            }
-        }
-    }
-    $env:COMP_WORDS = $null | Out-Null
-    $env:COMP_CWORD = $null | Out-Null
-    $env:_PROS_COMPLETE = $null | Out-Null
-}
-"""
+def _get_shell_script(shell: str) -> str:
+    with open(f'pros/autocomplete/{_SCRIPT_FILES[shell]}', 'r') as f:
+        return f.read()
 
 
 @add_completion_class
@@ -173,7 +66,7 @@ class PowerShellComplete(ZshComplete):
     """Shell completion for PowerShell and Windows PowerShell."""
 
     name = "powershell"
-    source_template = _SOURCE_POWERSHELL
+    source_template = _get_shell_script("powershell")
 
     def format_completion(self, item: CompletionItem) -> str:
         return super().format_completion(item).replace("\n", ",")
@@ -204,14 +97,6 @@ def setup_autocomplete(shell, config_file, force):
         'powershell': None,
     }
 
-    script_files = {
-        'bash': '.pros-complete.bash',
-        'zsh': '.pros-complete.zsh',
-        'fish': 'pros.fish',
-        'pwsh': 'pros-complete.ps1',
-        'powershell': 'pros-complete.ps1',
-    }
-
     if shell in ('pwsh', 'powershell') and config_file is None:
         try:
             profile_command = f'{shell} -NoLogo -NoProfile -Command "Write-Output $PROFILE"' if os.name == 'nt' else f"{shell} -NoLogo -NoProfile -Command 'Write-Output $PROFILE'"
@@ -230,14 +115,9 @@ def setup_autocomplete(shell, config_file, force):
             raise click.UsageError(f"Config directory {config_dir} does not exist. Please specify a valid config file.")
 
         # Write the autocomplete script to a shell script file
-        script_file = os.path.join(config_dir, script_files[shell]).replace('\\', '/')
+        script_file = os.path.join(config_dir, _SCRIPT_FILES[shell]).replace('\\', '/')
         with open(script_file, 'w') as f:
-            if shell == "bash":
-                f.write(_SOURCE_BASH)
-            elif shell == "zsh":
-                f.write(_SOURCE_ZSH)
-            elif shell in ('pwsh', 'powershell'):
-                f.write(_SOURCE_POWERSHELL)
+            f.write(_get_shell_script(shell))
 
         if shell in ('bash', 'zsh'):
             source_autocomplete = f". {script_file}\n"
@@ -260,8 +140,8 @@ def setup_autocomplete(shell, config_file, force):
             raise click.UsageError(f"Completions directory {config_dir} does not exist. Please specify a valid completion file.")
 
         # Write the autocomplete script to a shell script file
-        script_file = os.path.join(config_dir, script_files[shell]).replace('\\', '/')
+        script_file = os.path.join(config_dir, _SCRIPT_FILES[shell]).replace('\\', '/')
         with open(script_file, 'w') as f:
-            f.write(_SOURCE_FISH)
+            f.write(_get_shell_script(shell))
 
     ui.echo(f"Succesfully set up autocomplete for {shell} in {config_file}. Restart your shell to apply changes.")

--- a/pros/cli/misc_commands.py
+++ b/pros/cli/misc_commands.py
@@ -57,7 +57,7 @@ _SCRIPT_FILES = {
 
 
 def _get_shell_script(shell: str) -> str:
-    with open(f'pros/autocomplete/{_SCRIPT_FILES[shell]}', 'r') as f:
+    with open(f'{os.path.dirname(__file__)}/../autocomplete/{_SCRIPT_FILES[shell]}', 'r') as f:
         return f.read()
 
 

--- a/pros/cli/misc_commands.py
+++ b/pros/cli/misc_commands.py
@@ -81,6 +81,6 @@ def setup_autocomplete(shell, config_file):
                 f.write(source_autocomplete)
 
 
-    # if shell == 'fish':
-    #     with open(config_file, 'a') as f:
-    #         f.write("\n_PROS_COMPLETE=fish_source pros | source")
+    if shell == 'fish':
+        with open(config_file, 'w') as f:
+            subprocess.Popen(f"_PROS_COMPLETE={shell}_source pros", shell=True, stdout=f).wait()

--- a/pros/cli/misc_commands.py
+++ b/pros/cli/misc_commands.py
@@ -120,7 +120,8 @@ def setup_autocomplete(shell, config_path, force):
             raise click.UsageError(f"Config file {config_path} does not exist. Please specify a valid config file.")
 
         # Write the autocomplete script to a shell script file
-        script_file = config_path.parent / _SCRIPT_FILES[shell]
+        script_file = Path(click.get_app_dir("PROS")) / "autocomplete" / _SCRIPT_FILES[shell]
+        script_file.parent.mkdir(exist_ok=True)
         with script_file.open('w') as f:
             f.write(_get_shell_script(shell))
 

--- a/pros/cli/misc_commands.py
+++ b/pros/cli/misc_commands.py
@@ -82,7 +82,8 @@ def setup_autocomplete(shell, config_file):
         # Write the autocomplete script to a shell script file
         script_file = os.path.join(config_dir, f".pros-complete.{shell}")
         with open(script_file, 'w') as f:
-            subprocess.Popen(f"_PROS_COMPLETE={shell}_source pros", shell=True, stdout=f).wait()
+            if subprocess.Popen(f"_PROS_COMPLETE={shell}_source pros", shell=True, stdout=f).wait():
+                raise click.ClickException(f"Failed to write autocomplete script to {script_file}")
 
         # Source the autocomplete script in the config file
         source_autocomplete = f". ~/.pros-complete.{shell}\n"
@@ -93,6 +94,7 @@ def setup_autocomplete(shell, config_file):
                 f.write(source_autocomplete)
     elif shell == 'fish':
         with open(config_file, 'w') as f:
-            subprocess.Popen(f"_PROS_COMPLETE={shell}_source pros", shell=True, stdout=f).wait()
+            if subprocess.Popen(f"_PROS_COMPLETE={shell}_source pros", shell=True, stdout=f).wait():
+                raise click.ClickException(f"Failed to write autocomplete script to {config_file}")
 
     ui.echo(f"Succesfully set up autocomplete for PROS CLI for {shell} in {config_file}")

--- a/pros/cli/misc_commands.py
+++ b/pros/cli/misc_commands.py
@@ -40,3 +40,23 @@ def upgrade(force_check, no_install):
                 ui.logger(__name__).error(f'This manifest cannot perform the upgrade.')
                 return -3
             ui.finalize('upgradeComplete', manager.perform_upgrade())
+
+
+@misc_commands_cli.command()
+@click.argument('shell', type=click.Choice(['bash', 'zsh', 'fish']), required=True)
+@click.argument('rcfile', type=click.Path(file_okay=True, dir_okay=False), required=True)
+@default_options
+def setup_autocomplete(shell, rcfile):
+    ui.echo(f"Setting up autocomplete for PROS CLI for {shell} shell in {rcfile}...")
+
+    if shell == 'bash':
+        with open(rcfile, 'a') as f:
+            f.write('\neval "$(_PROS_COMPLETE=bash_source pros)"')
+
+    if shell == 'zsh':
+        with open(rcfile, 'a') as f:
+            f.write('\neval "$(_PROS_COMPLETE=zsh_source pros)"')
+
+    if shell == 'fish':
+        with open(rcfile, 'a') as f:
+            f.write("\n_PROS_COMPLETE=fish_source pros | source")

--- a/pros/cli/misc_commands.py
+++ b/pros/cli/misc_commands.py
@@ -113,8 +113,9 @@ class PowerShellComplete(ZshComplete):
 @misc_commands_cli.command()
 @click.argument('shell', type=click.Choice(['bash', 'zsh', 'fish', 'pwsh', 'powershell']), required=True)
 @click.argument('config_file', type=click.Path(file_okay=True, dir_okay=False), default=None, required=False)
+@click.option('--force', '-f', is_flag=True, default=False, help='Skip confirmation prompts')
 @default_options
-def setup_autocomplete(shell, config_file):
+def setup_autocomplete(shell, config_file, force):
     """
     Set up autocomplete for PROS CLI in the specified shell
 
@@ -133,7 +134,6 @@ def setup_autocomplete(shell, config_file):
         'pwsh': None,
         'powershell': None,
     }
-
 
     if shell in ('pwsh', 'powershell') and config_file is None:
         try:
@@ -163,7 +163,7 @@ def setup_autocomplete(shell, config_file):
                 raise click.ClickException(f"Failed to write autocomplete script to {script_file}") from exc
 
         source_autocomplete = f". {script_file}\n"
-        if ui.confirm(f"Add the autocomplete script to {config_file}?", default=True):
+        if force or ui.confirm(f"Add the autocomplete script to {config_file}?", default=True):
             # Source the autocomplete script in the config file
             with open(config_file, 'r+') as f:
                 # Only append if the source command is not already in the file
@@ -197,7 +197,7 @@ def setup_autocomplete(shell, config_file):
             f.write(_SOURCE_POWERSHELL)
 
         source_autocomplete = f"{script_file} | Invoke-Expression\n"
-        if ui.confirm(f"Add the autocomplete script to {config_file}?", default=True):
+        if force or ui.confirm(f"Add the autocomplete script to {config_file}?", default=True):
             # Source the autocomplete script in the config file
             with open(config_file, 'r+') as f:
                 # Only append if the source command is not already in the file

--- a/pros/cli/misc_commands.py
+++ b/pros/cli/misc_commands.py
@@ -138,7 +138,7 @@ def setup_autocomplete(shell, config_file):
     if shell in ('pwsh', 'powershell') and config_file is None:
         try:
             profile_command = f'{shell} -c "echo $profile"' if os.name == 'nt' else f"{shell} -c 'echo $PROFILE'"
-            default_config_files[shell] = subprocess.run(profile_command, capture_output=True, check=True).stdout.decode().strip()
+            default_config_files[shell] = subprocess.run(profile_command, shell=True, capture_output=True, check=True).stdout.decode().strip()
         except subprocess.CalledProcessError as exc:
             raise click.UsageError("Failed to determine the PowerShell profile path. Please specify a valid config file.") from exc
 


### PR DESCRIPTION
#### Summary:

- Adds a command to setup autocomplete for bash, zsh, fish, pwsh, and powershell
- Adds a custom PowerShell script to register an argument completer


Example:
```bash
pros setup-autocomplete bash
```

#### Motivation:
Since we upgraded to click 8 in #307 it is possible to use click's shell completion feature. This will allow users to quickly select commands in the supported shells.

##### References (optional):
Closes #138 

#### Test Plan:

- [x] bash (Ubuntu WSL)
- [x] zsh (Ubuntu WSL)
- [x] fish (Ubuntu WSL)
- [x] pwsh (Ubuntu WSL)
- [x] bash (Windows)
- [ ] zsh (Windows)
   - Autocomplete doesn't work
- [x] pwsh (Windows)
- [x] powershell (Windows)
- [x] bash (macOS)
- [x] zsh (macOS)
- [x] fish (macOS)
- [ ] pwsh (macOS)

1. Run `pros setup-autocomplete {shell}`
2. Start typing a pros command, then press your autocomplete key (default should be double press TAB)
3. Ensure a completion is shown, example below for fish shell on linux
![image](https://github.com/purduesigbots/pros-cli/assets/34776435/029dadec-b34a-47cd-806a-5a4e8c98f888)
