### PR TITLE
🚸 Apply liblvgl when upgrading to PROS 4

### DIFF
--- a/pros/cli/conductor.py
+++ b/pros/cli/conductor.py
@@ -159,7 +159,7 @@ def upgrade(ctx: click.Context, project: c.Project, query: c.BaseTemplate, **kwa
     """
     analytics.send("upgrade-project")
     if not query.name:
-        for template in project.templates.keys():
+        for template in tuple(project.templates.keys()):
             click.secho(f'Upgrading {template}', color='yellow')
             q = c.BaseTemplate.create_query(name=template, target=project.target,
                                             supported_kernels=project.templates['kernel'].version)

--- a/pros/conductor/conductor.py
+++ b/pros/conductor/conductor.py
@@ -282,6 +282,8 @@ class Conductor(Config):
             raise dont_send(
                 InvalidTemplateException(f'Could not find a template satisfying {identifier} for {project.target}'))
 
+        apply_liblvgl = False  # flag to apply liblvgl if upgrading to PROS 4
+
         # warn and prompt user if upgrading to PROS 4 or downgrading to PROS 3
         if template.name == 'kernel':
             isProject = Project.find_project("")
@@ -294,6 +296,7 @@ class Conductor(Config):
                         if not confirm:
                             raise dont_send(
                                 InvalidTemplateException(f'Not upgrading'))
+                        apply_liblvgl = True
                     if template.version[0] == '3' and curr_proj.kernel[0] == '4':
                         confirm = ui.confirm(f'Warning! Downgrading project to PROS 3 will cause breaking changes. '
                                              f'Do you still want to downgrade?')
@@ -333,6 +336,8 @@ class Conductor(Config):
                                    force_user=kwargs.pop('force_user', False),
                                    remove_empty_directories=kwargs.pop('remove_empty_directories', False))
             ui.finalize('apply', f'Finished applying {template.identifier} to {project.location}')
+            if apply_liblvgl:
+                self.apply_template(project=project, identifier="liblvgl")
         elif valid_action != TemplateAction.AlreadyInstalled:
             raise dont_send(
                 InvalidTemplateException(f'Could not install {template.identifier} because it is {valid_action.name},'


### PR DESCRIPTION
#### Summary:
Automatically apply liblvgl when upgrading a PROS 3 project to PROS 4, fetch the template if necessary

#### Motivation:
liblvgl is needed for LLEMU on PROS 4

#### Test Plan:
- [x] Create a PROS 3 project
- [x] Upgrade to PROS 4
- [x] Ensure that liblvgl is applied
![image](https://github.com/purduesigbots/pros-cli/assets/34776435/1c1505ae-4dfa-42af-bdf1-a2063dba0127)