### PR TITLE
🧹 Remove PROS 4 Prompts

### DIFF
--- a/pros/conductor/conductor.py
+++ b/pros/conductor/conductor.py
@@ -303,20 +303,7 @@ class Conductor(Config):
                         if not confirm:
                             raise dont_send(
                                 InvalidTemplateException(f'Not downgrading'))
-            elif not project.use_early_access and template.version[0] == '3' and not self.warn_early_access:
-                confirm = ui.confirm(f'PROS 4 is now in early access. '
-                                     f'Please use the --early-access flag if you would like to use it.\n'
-                                     f'Do you want to use PROS 4 instead?')
-                self.warn_early_access = True
-                if confirm: # use pros 4
-                    project.use_early_access = True
-                    project.save()
-                    kwargs['version'] = '>=0'
-                    kwargs['early_access'] = True
-                    # Recall the function with early access enabled
-                    return self.apply_template(project, identifier, **kwargs)
-                    
-                self.save()
+
         if not isinstance(template, LocalTemplate):
             with ui.Notification():
                 template = self.fetch_template(self.get_depot(template.metadata['origin']), template, **kwargs)
@@ -371,22 +358,8 @@ class Conductor(Config):
         else:
             use_early_access = self.use_early_access
         kwargs["early_access"] = use_early_access
-        if kwargs["version_source"]: # If true, then the user has not specified a version
-            if not use_early_access and self.warn_early_access:
-                ui.echo(f"PROS 4 is now in early access. "
-                        f"If you would like to use it, use the --early-access flag.")
-            elif not use_early_access and not self.warn_early_access:
-                confirm = ui.confirm(f'PROS 4 is now in early access. '
-                                     f'Please use the --early-access flag if you would like to use it.\n'
-                                     f'Do you want to use PROS 4 instead?')
-                self.warn_early_access = True
-                if confirm:
-                    use_early_access = True
-                    kwargs['early_access'] = True
-            elif use_early_access:
-                ui.echo(f'Early access is enabled. Using PROS 4.')
-        elif use_early_access:
-            ui.echo(f'Early access is enabled.')
+        if use_early_access:
+            ui.echo(f'Early access is enabled. Experimental features have been applied.')
 
         if not is_pathname_valid(str(Path(path).absolute())):
             raise dont_send(ValueError('Project path contains invalid characters.'))


### PR DESCRIPTION
#### Summary:
Remove PROS 4 prompts when enabling early access.

#### Motivation:
Support the PROS 4 GA as it is no longer early access.

#### Test Plan:
Generally, just make sure we didn't break existing functionality. Expecting normal functionality with the PROS 4 prompt removed.

- [x] Create normal PROS project (expected: normal project is created on latest mainline version)
- [x] Create early access PROS project (expected: early access project is created with latest early access version)
