### PR TITLE
🧹Remove Okapilib as a default template for PROS 4

### DIFF
--- a/pros/conductor/conductor.py
+++ b/pros/conductor/conductor.py
@@ -383,6 +383,9 @@ class Conductor(Config):
         if not no_default_libs:
             libraries = self.early_access_libraries if proj.use_early_access and (kwargs.get("version", ">").startswith("4") or kwargs.get("version", ">").startswith(">")) else self.default_libraries
 
+            if kwargs['version'][0] == '>' or kwargs['version'][0] == '4':
+                libraries[proj.target].remove('okapilib')
+
             for library in libraries[proj.target]:
                 try:
                     # remove kernel version so that latest template satisfying query is correctly selected


### PR DESCRIPTION
#### Summary:
When creating a PROS 4 project, do not apply PROS 4 as a default template. Okapilib will behave as a normal template for PROS 4 and newer.

#### Motivation:
This change was requested for the release of PROS 4.

#### Test Plan:
Note on CLI release that PROS 4 will be the latest kernel version on mainline so we check if a project with the latest kernel version is used.

- [x] Create a PROS 3 project (okapi should be applied as a default template, old behavior)
![Screenshot 2024-05-17 at 3 49 03 PM](https://github.com/purduesigbots/pros-cli/assets/71904196/fa459940-6cfe-4287-a9a1-e9e465432504)

- [x] Create a PROS 4 project (okapi should not be applied as a default template)
![Screenshot 2024-05-17 at 3 49 52 PM](https://github.com/purduesigbots/pros-cli/assets/71904196/586a32a9-2197-47b4-ae4d-3a0a0186c694)

- [x] Create a PROS project with the latest version (okapi should not be applied, this is guaranteed to be a PROS 4 project or newer when the new CLI version releases)
![Screenshot 2024-05-17 at 3 51 11 PM](https://github.com/purduesigbots/pros-cli/assets/71904196/b372a004-8850-4489-85c4-9c671abdcc17)

