### PR TITLE
⬇️ Downgrade rich click

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click>=8
-rich-click
+rich-click==1.7.4
 pyserial
 cachetools
 requests


### PR DESCRIPTION
#### Summary:
Downgrade rich click to 1.7.4.

#### Motivation:
A new version of rich click (1.8.0) breaks our existing UI, downgrading to restore the existing UI. 

##### References (optional):
Credit @mayankpatibandla for finding this

#### Test Plan

- [x] Test if rich click 1.7.4 restores the existing UI

![Screenshot 2024-05-18 at 11 20 51 AM](https://github.com/purduesigbots/pros-cli/assets/71904196/1219e9ee-1ae2-4809-ad18-48fc48d7139d)
