### PR TITLE
🚸 Apply liblvgl as a default template for PROS 4

### DIFF
--- a/pros/conductor/conductor.py
+++ b/pros/conductor/conductor.py
@@ -107,7 +107,7 @@ class Conductor(Config):
             needs_saving = True
         if self.default_libraries is None:
             self.default_libraries = {
-                'v5': ['okapilib'],
+                'v5': ['okapilib', 'liblvgl'],
                 'cortex': []
             }
             needs_saving = True
@@ -385,6 +385,9 @@ class Conductor(Config):
 
             if kwargs['version'][0] == '>' or kwargs['version'][0] == '4':
                 libraries[proj.target].remove('okapilib')
+
+            if 'liblvgl' in libraries[proj.target] and kwargs['version'][0] != '>' and kwargs['version'][0] != '4':
+                libraries[proj.target].remove('liblvgl')
 
             for library in libraries[proj.target]:
                 try:


### PR DESCRIPTION
#### Summary:
Add liblvgl as a default template for only PROS 4 or newer projects.

#### Motivation:
As PROS 4 moves into mainline, liblvgl should become a default template as it was in the early access depot.

#### Test Plan:
It is not currently possible to test if liblvgl is applied when PROS 4 is in mainline but as proven from creating PROS 4 in early access, the template will be applied when creating a PROS 4 project regardless of depot. The test also proves liblvgl will not be applied when attempting to create a PROS 3 project.

- [ ] Create a PROS 3 project (liblvgl should not be applied)
![Screenshot 2024-05-18 at 2 07 06 PM](https://github.com/purduesigbots/pros-cli/assets/71904196/c7c25f23-59f2-4d37-929b-bf88dd2c51e1)

- [ ] Create a PROS 4 project (liblvgl should be applied)
![Screenshot 2024-05-18 at 2 07 19 PM](https://github.com/purduesigbots/pros-cli/assets/71904196/79409504-e398-4928-8099-0ccb92956878)
