### PR TITLE
🐛 Fix removing default template

### DIFF
--- a/pros/conductor/conductor.py
+++ b/pros/conductor/conductor.py
@@ -383,13 +383,13 @@ class Conductor(Config):
         if not no_default_libs:
             libraries = self.early_access_libraries if proj.use_early_access and (kwargs.get("version", ">").startswith("4") or kwargs.get("version", ">").startswith(">")) else self.default_libraries
 
-            if kwargs['version'][0] == '>' or kwargs['version'][0] == '4':
-                libraries[proj.target].remove('okapilib')
-
-            if 'liblvgl' in libraries[proj.target] and kwargs['version'][0] != '>' and kwargs['version'][0] != '4':
-                libraries[proj.target].remove('liblvgl')
-
             for library in libraries[proj.target]:
+                if kwargs['version'][0] == '>' or kwargs['version'][0] == '4':
+                    if library == "okapilib":
+                        continue
+                if kwargs['version'][0] != '>' and kwargs['version'][0] != '4':
+                    if library == "liblvgl":
+                        continue
                 try:
                     # remove kernel version so that latest template satisfying query is correctly selected
                     if 'version' in kwargs:


### PR DESCRIPTION
#### Summary:
Instead of removing the template from the list, it will instead skip over it when applying the templates.

#### Motivation:
There is a bug introduced in 3.5.2 where okapilib is removed from the default templates list when creating a new project which causes issues when creating multiple projects.

#### Test Plan:

- [x] Create two projects and check if the second one causes an error

On `master`:
![image](https://github.com/purduesigbots/pros-cli/assets/34776435/5b50e681-af3a-45dd-a03c-70eb7ac678cb)

On `hotfix/remove-default-templates`:
![image](https://github.com/purduesigbots/pros-cli/assets/34776435/49907a5b-66c9-4f1c-978c-afe5cd78f884)

