### PR TITLE
🐛 Fix removed kernel version for PROS 3 projects

### DIFF
--- a/pros/conductor/conductor.py
+++ b/pros/conductor/conductor.py
@@ -383,11 +383,12 @@ class Conductor(Config):
         if not no_default_libs:
             libraries = self.early_access_libraries if proj.use_early_access and (kwargs.get("version", ">").startswith("4") or kwargs.get("version", ">").startswith(">")) else self.default_libraries
 
+            version = kwargs['version'][0]
             for library in libraries[proj.target]:
-                if kwargs['version'][0] == '>' or kwargs['version'][0] == '4':
+                if version == '>' or version == '4':
                     if library == "okapilib":
                         continue
-                if kwargs['version'][0] != '>' and kwargs['version'][0] != '4':
+                if version != '>' and version != '4':
                     if library == "liblvgl":
                         continue
                 try:


### PR DESCRIPTION
#### Summary:
Create a copy of the kernel version before entering the loop

#### Motivation:
Bug introduced in #357 where the kernel version is removed from kwargs after the first iteration

#### Test Plan:
- [x] Create a PROS 3 project
![image](https://github.com/purduesigbots/pros-cli/assets/34776435/648145ed-e926-492a-aa5f-6e8e9037d875)
