### PR TITLE
🐛Applies liblvgl without expiremental features

### DIFF
--- a/pros/conductor/conductor.py
+++ b/pros/conductor/conductor.py
@@ -85,8 +85,8 @@ class Conductor(Config):
         self.early_access_local_templates: Set[LocalTemplate] = set()
         self.depots: Dict[str, Depot] = {}
         self.default_target: str = 'v5'
-        self.default_libraries: Dict[str, List[str]] = None
-        self.early_access_libraries: Dict[str, List[str]] = None
+        self.pros_3_default_libraries: Dict[str, List[str]] = None
+        self.pros_4_default_libraries: Dict[str, List[str]] = None
         self.use_early_access = False
         self.warn_early_access = False
         super(Conductor, self).__init__(file)
@@ -105,29 +105,29 @@ class Conductor(Config):
         if self.default_target is None:
             self.default_target = 'v5'
             needs_saving = True
-        if self.default_libraries is None:
-            self.default_libraries = {
-                'v5': ['okapilib', 'liblvgl'],
+        if self.pros_3_default_libraries is None:
+            self.pros_3_default_libraries = {
+                'v5': ['okapilib'],
                 'cortex': []
             }
             needs_saving = True
-        if self.early_access_libraries is None or len(self.early_access_libraries['v5']) != 2:
-            self.early_access_libraries = {
-                'v5': ['liblvgl', 'okapilib'],
+        if self.pros_4_default_libraries is None:
+            self.pros_4_default_libraries = {
+                'v5': ['liblvgl'],
                 'cortex': []
             }
             needs_saving = True
-        if 'v5' not in self.default_libraries:
-            self.default_libraries['v5'] = []
+        if 'v5' not in self.pros_3_default_libraries:
+            self.pros_3_default_libraries['v5'] = ['okapilib']
             needs_saving = True
-        if 'cortex' not in self.default_libraries:
-            self.default_libraries['cortex'] = []
+        if 'cortex' not in self.pros_3_default_libraries:
+            self.pros_3_default_libraries['cortex'] = []
             needs_saving = True
-        if 'v5' not in self.early_access_libraries:
-            self.early_access_libraries['v5'] = []
+        if 'v5' not in self.pros_4_default_libraries:
+            self.pros_4_default_libraries['v5'] = ['liblvgl']
             needs_saving = True
-        if 'cortex' not in self.early_access_libraries:
-            self.early_access_libraries['cortex'] = []
+        if 'cortex' not in self.pros_4_default_libraries:
+            self.pros_4_default_libraries['cortex'] = []
             needs_saving = True
         if needs_saving:
             self.save()
@@ -381,16 +381,9 @@ class Conductor(Config):
         proj.save()
 
         if not no_default_libs:
-            libraries = self.early_access_libraries if proj.use_early_access and (kwargs.get("version", ">").startswith("4") or kwargs.get("version", ">").startswith(">")) else self.default_libraries
-
-            version = kwargs['version'][0]
+            major_version = proj.kernel[0]
+            libraries = self.pros_4_default_libraries if major_version == '4' else self.pros_3_default_libraries
             for library in libraries[proj.target]:
-                if version == '>' or version == '4':
-                    if library == "okapilib":
-                        continue
-                if version != '>' and version != '4':
-                    if library == "liblvgl":
-                        continue
                 try:
                     # remove kernel version so that latest template satisfying query is correctly selected
                     if 'version' in kwargs:

--- a/pros/conductor/project/__init__.py
+++ b/pros/conductor/project/__init__.py
@@ -34,7 +34,7 @@ class Project(Config):
 
         if defaults is None:
             defaults = {}
-        self.target: str = defaults.get('target', 'cortex').lower()  # VEX Hardware target (V5/Cortex)
+        self.target: str = defaults.get('target', 'v5').lower()  # VEX Hardware target (V5/Cortex)
         self.templates: Dict[str, Template] = defaults.get('templates', {})
         self.upload_options: Dict = defaults.get('upload_options', {})
         self.project_name: str = defaults.get('project_name', None)


### PR DESCRIPTION

#### Summary:
<!-- Provide a concise description of your changes -->
Adjusts the default templates such that they are based on kernel version, not if you are in experimental / early access mode.
Has v5 be the default project in the project class. it is already set as the default in new conductor files. 
#### Motivation:
<!-- Provide a brief description of why you think these changes need to be made -->
Fixes the issue of liblvgl not being applied when you have never turned on early access. 

#### Test Plan:
<!-- Provide a list of steps that can be taken to verify these changes work as intended -->

- [x] Creating a pros 4 project after reseting conductor applies only liblvgl
![image](https://github.com/purduesigbots/pros-cli/assets/50681033/0baddaf3-2e88-4f58-a3c8-036e4a6cc7e1)

- [x] Creating a pros 3 project applies only okapilib
![image](https://github.com/purduesigbots/pros-cli/assets/50681033/4db1fbf0-a485-49a6-a7b8-a5bc676c5b71)


