### PR TITLE
💚 Add autocomplete scripts to macOS PyInstaller

### DIFF
--- a/pros-macos.spec
+++ b/pros-macos.spec
@@ -15,7 +15,7 @@ a = Analysis(
     ['pros/cli/main.py'],
     pathex=[],
     binaries=[],
-    datas=[],
+    datas=[('pros/autocomplete/*', 'pros/autocomplete')],
     hiddenimports=[],
     hookspath=[],
     hooksconfig={},


### PR DESCRIPTION
#### Summary:
Bundles the autocomplete scripts with the binary for macOS

#### Motivation:
#363 only did it for Windows and Linux because there is a separate spec file for macOS

#### Test Plan:

- [x] Ensure PyInstaller builds
- [x] Check if `pros setup-autocomplete` works
