### PR TITLE
🐛Fix Error Reading project.pros File with Certain Chinese Characters on Windows

### DIFF
--- a/pros/config/config.py
+++ b/pros/config/config.py
@@ -25,7 +25,7 @@ class Config(object):
         if file:
             # If the file already exists, update this new config with the values in the file
             if os.path.isfile(file):
-                with open(file, 'r') as f:
+                with open(file, 'r', encoding ='utf-8') as f:
                     try:
                         result = jsonpickle.decode(f.read())
                         if isinstance(result, dict):


### PR DESCRIPTION
#### Summary:
Fixes a bug where the project.pros file couldn't be read with certain Chinese characters on Windows devices

#### Motivation:
Fixes the Chinese character issue

##### References (optional):
Closes #376

#### Test Plan:
- [ ] Create a new PROS project with the latest version
- [ ] Open the project.pros file
- [ ] Replace the kernel's location with `"C:\\Users\\杨\\AppData\\Roaming\\PROS\\templates\\kernel@4.0.6"` 
- [ ] run `pros c info-project`

