### PR TITLE
🐛 Depot bug fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ out/
 *.zip
 *_pros_capture.png
 
-venv/
+*venv/
+.DS_Store
 
 *.pyc

--- a/pros/common/sentry.py
+++ b/pros/common/sentry.py
@@ -1,6 +1,8 @@
 from typing import *
 
 import click
+import os
+import sys
 
 import pros.common.ui as ui
 
@@ -99,8 +101,16 @@ def add_context(obj: object, override_handlers: bool = True, key: str = None) ->
 
     from sentry_sdk import configure_scope
     with configure_scope() as scope:
-        scope.set_extra((key or obj.__class__.__qualname__), jsonpickle.pickler.Pickler(unpicklable=False).flatten(obj))
-
+        try:
+            scope.set_extra((key or obj.__class__.__qualname__), jsonpickle.pickler.Pickler(unpicklable=False).flatten(obj))
+        except:
+            if ui.confirm("Malformed depot detected, do you want to reset conductor.pros? This will remove all depots and templates. You will be unable to create a new PROS project if you do not have internet connection."):   
+                file = os.path.join(click.get_app_dir('PROS'), 'conductor.pros')
+                if os.path.exists(file):
+                    os.remove(file)
+                    ui.echo("Conductor was reset")
+                    sys.exit()
+                    
     if override_handlers:
         jsonpickle.handlers.unregister(BaseTemplate)
 


### PR DESCRIPTION
#### Summary:
Wrapped pickle.pickler in a Try, Except. Prompted user to reset depots using the reset depots function.

#### Motivation:
Prevents an error message after having a malformed depot.

##### References (optional):
Closes #342 

#### Test Plan:
With npm installed:
powershell:
```powershell
mkdir depot;
'[{"py/object":"pros.conductor.templates.base_template.BaseTemplate","metadata":{},"name":""}]' | Out-File -FilePath ./depot/depot.json ascii;
Start-Process npx -ArgumentList "-y http-server depot -p 8080";
sleep 6;
pros c add-depot malformed http://127.0.0.1:8080/depot.json;
pros c query-templates --force-refresh some-text;
pros --version
```
not windows:
```bash
mkdir depot 
echo '[{"py/object":"pros.conductor.templates.base_template.BaseTemplate","metadata":{},"name":""}]' >./depot/depot.json 
npx -y http-server depot -p 8080 & 
sleep 6
pros c add-depot malformed http://127.0.0.1:8080/depot.json
pros c query-templates --force-refresh some-text
pros --version
```
