### PR TITLE
✨ Remove kernel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,6 @@ out/
 *.zip
 *_pros_capture.png
 
-venv/
-
+*venv/
+.DS_Store
 *.pyc

--- a/pros/cli/conductor.py
+++ b/pros/cli/conductor.py
@@ -237,7 +237,7 @@ def new_project(ctx: click.Context, path: str, target: str, version: str,
         ui.echo('New PROS Project was created:', output_machine=False)
         ctx.invoke(info_project, project=project)
 
-        if compile_after or build_cache:
+        if (compile_after or build_cache) and not no_default_libs:
             with ui.Notification():
                 ui.echo('Building project...')
                 exit_code = project.compile([], scan_build=build_cache)

--- a/pros/conductor/conductor.py
+++ b/pros/conductor/conductor.py
@@ -377,8 +377,7 @@ class Conductor(Config):
         if 'version' in kwargs:
             if kwargs['version'] == 'latest':
                 kwargs['version'] = '>=0'
-            if not no_default_libs:
-                self.apply_template(proj, identifier='kernel', **kwargs)
+            self.apply_template(proj, identifier='kernel', **kwargs)
         proj.save()
 
         if not no_default_libs:

--- a/pros/conductor/conductor.py
+++ b/pros/conductor/conductor.py
@@ -377,7 +377,8 @@ class Conductor(Config):
         if 'version' in kwargs:
             if kwargs['version'] == 'latest':
                 kwargs['version'] = '>=0'
-            self.apply_template(proj, identifier='kernel', **kwargs)
+            if not no_default_libs:
+                self.apply_template(proj, identifier='kernel', **kwargs)
         proj.save()
 
         if not no_default_libs:

--- a/pros/conductor/project/ProjectReport.py
+++ b/pros/conductor/project/ProjectReport.py
@@ -17,8 +17,10 @@ class ProjectReport(object):
             f' ({self.project["name"]})' if self.project["name"] else ''
         s += '\n'
         rows = [t.values() for t in self.project["templates"]]
-        headers = [h.capitalize() for h in self.project["templates"][0].keys()]
+        
+        headers = [h.capitalize() for h in self.project["templates"][0].keys()]if self.project["templates"] else []
         s += tabulate.tabulate(rows, headers=headers)
+
         return s
 
     def __getstate__(self):

--- a/pros/conductor/project/__init__.py
+++ b/pros/conductor/project/__init__.py
@@ -166,8 +166,6 @@ class Project(Config):
     def remove_template(self, template: Template, remove_user: bool = False, remove_empty_directories: bool = True):
         if not self.template_is_installed(template):
             raise ValueError(f'{template.identifier} is not installed on this project.')
-        if template.name == 'kernel':
-            raise ValueError(f'Cannot remove the kernel template. Maybe create a new project?')
 
         real_template = LocalTemplate(orig=template, location=self.location)
         transaction = Transaction(self.location, set(self.all_files))


### PR DESCRIPTION
#### Summary:
Made a change in init_py to prevent an error message when Kernel is uninstalled and then created an if statement around the no_default_libs function to allow for a project to be created without any templates present.

#### Motivation:
So that projects can be created without any templates and Kernel can be uninstalled from templates.

##### References (optional):
#369 

#### Test Plan:
Run pros c uninstall kernel and see that the project is still allowed to be created. 
Run --no_default_libs when creating a new project and see that the project is still able to be created.

