### PR TITLE
🐛 Fix project upload description

### DIFF
--- a/pros/cli/upload.py
+++ b/pros/cli/upload.py
@@ -76,6 +76,8 @@ def upload(path: Optional[str], project: Optional[c.Project], port: str, **kwarg
             kwargs['slot'] = 1
         if 'icon' in options and kwargs.get('icon','pros') == 'pros':
             kwargs.pop('icon')
+        if 'description' in options and kwargs.get('description','Made with PROS') == 'Made with PROS':
+            kwargs.pop('description')
         if 'after' in options and kwargs.get('after','screen') is None:
             kwargs.pop('after')
 


### PR DESCRIPTION
#### Summary:

This fixes the `Project Description` set in the `project.pros` file to be used when uploading.

The fix follows the same formatting that is done when checking the `Project Logo`

#### Motivation:

Allows people to put descriptions on their programs, which can be extremely useful.

#### Test Plan:

- [ ] Install using `pip install -e ./`
- [ ] Test upload doing `pros upload`
- [ ] Check project description on V5 brain

#### Pictures:

![bruh](https://github.com/user-attachments/assets/2e26bc69-dda8-40bb-a374-66f70d245722)
![image](https://github.com/user-attachments/assets/7d3e8de7-ebc0-4eda-89fc-d6b1467fb0b0)
