### PR TITLE
:bug: determine joystick status by pid in resolve_v5_port

### DIFF
--- a/pros/cli/common.py
+++ b/pros/cli/common.py
@@ -268,7 +268,7 @@ def resolve_v5_port(port: Optional[str], type: str, quiet: bool = False) -> Tupl
                 return None, False
         else:
             port = ports[0].device
-            is_joystick = type == 'user' and 'Controller' in ports[0].description
+            is_joystick = type == 'user' and ('Controller' in ports[0].description or ports[0].pid == 0x503)
             logger(__name__).info('Automatically selected {}'.format(port))
     return port, is_joystick
 


### PR DESCRIPTION
#### Summary:
<!-- Provide a concise description of your changes -->
In addition to checking the description, also check if the pid is equal to 0x503 to determine if a device is a joystick in resolve_v5_port
#### Motivation:
<!-- Provide a brief description of why you think these changes need to be made -->
The value of is_joystick is crucial to the functionality of the pros terminal, as if it is a joystick the controller must be switched to the download channel. On Windows computers, vex brains and controllers show up with a generic description of "USB Serial Device", unless you install the vex USB drivers, which gives them their proper names. This means that currently is_joystick returns False for controllers on Windows computers without the vex drivers, which breaks pros terminal on Windows.
##### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->
#383 
#### Test Plan:
<!-- Provide a list of steps that can be taken to verify these changes work as intended -->

- [ ] test that pros terminal works over controllers on Windows computers
- [ ] test that nothing else has broken, e.g. uploading programs, pros terminal from brain, pros terminal on Linux and macOS
