### PR TITLE
Switch to importlib

### DIFF
--- a/pros/common/utils.py
+++ b/pros/common/utils.py
@@ -35,10 +35,22 @@ def get_version():
         module = pros.cli.main.__name__
         for dist in distributions():
             for entry_point in dist.entry_points:
+                try:
+                    entry_points = dist.entry_points
+                except Exception:
+                    continue
                 if entry_point.group == "console_scripts":
-                    if entry_point.module == module:
-                        if dist.version is not None:
-                            return dist.version
+                    ep_module = getattr(entry_point, "module", None)
+                    if ep_module is None:
+                        value = getattr(entry_point, "value", "") or ""
+                        ep_module = value.split(":", 1)[0] if value else None
+                    if ep_module == module:
+                        try:
+                             version = dist.version
+                        except Exception:
+                            continue
+                        if version is not None:
+                            return version
     raise RuntimeError('Could not determine version')
 
 

--- a/pros/common/utils.py
+++ b/pros/common/utils.py
@@ -27,19 +27,18 @@ def get_version():
     except:
         pass
     try:
-        import pkg_resources
+        from importlib.metadata import distributions
     except ImportError:
         pass
     else:
         import pros.cli.main
         module = pros.cli.main.__name__
-        for dist in pkg_resources.working_set:
-            scripts = dist.get_entry_map().get('console_scripts') or {}
-            for script_name, entry_point in iter(scripts.items()):
-                if entry_point.module_name == module:
-                    ver = dist.version
-                    if ver is not None:
-                        return ver
+        for dist in distributions():
+            for entry_point in dist.entry_points:
+                if entry_point.group == "console_scripts":
+                    if entry_point.module == module:
+                        if dist.version is not None:
+                            return dist.version
     raise RuntimeError('Could not determine version')
 
 

--- a/pros/upgrade/manifests/upgrade_manifest_v2.py
+++ b/pros/upgrade/manifests/upgrade_manifest_v2.py
@@ -2,7 +2,6 @@ import sys
 from enum import Enum
 from typing import *
 
-from importlib.metadata import distributions
 
 from pros.common import logger
 from .upgrade_manifest_v1 import UpgradeManifestV1
@@ -51,6 +50,11 @@ class UpgradeManifestV2(UpgradeManifestV1):
                     self._platform = PlatformsV2.MacOS
         else:
             try:
+                try:
+                    from importlib.metadata import distributions
+                except ImportError:
+                    from importlib_metadata import distributions  # type: ignore
+
                 for dist in distributions():
                     name = (dist.metadata.get("Name") or "").lower()
                     if name.startswith("pros-cli"):

--- a/pros/upgrade/manifests/upgrade_manifest_v2.py
+++ b/pros/upgrade/manifests/upgrade_manifest_v2.py
@@ -2,6 +2,8 @@ import sys
 from enum import Enum
 from typing import *
 
+from importlib.metadata import distributions
+
 from pros.common import logger
 from .upgrade_manifest_v1 import UpgradeManifestV1
 from ..instructions import UpgradeInstruction, UpgradeResult, NothingInstruction
@@ -27,7 +29,6 @@ class UpgradeManifestV2(UpgradeManifestV1):
         self.platform_instructions: Dict[PlatformsV2, UpgradeInstruction] = {}
 
         self._platform: 'PlatformsV2' = None
-
         self._last_file: Optional[str] = None
 
     @property
@@ -50,11 +51,12 @@ class UpgradeManifestV2(UpgradeManifestV1):
                     self._platform = PlatformsV2.MacOS
         else:
             try:
-                from pip._vendor import pkg_resources
-                results = [p for p in pkg_resources.working_set if p.project_name.startswith('pros-cli')]
-                if any(results):
-                    self._platform = PlatformsV2.Pip
-            except ImportError:
+                for dist in distributions():
+                    name = (dist.metadata.get("Name") or "").lower()
+                    if name.startswith("pros-cli"):
+                        self._platform = PlatformsV2.Pip
+                        break
+            except Exception:
                 pass
         if not self._platform:
             self._platform = PlatformsV2.Unknown
@@ -65,7 +67,9 @@ class UpgradeManifestV2(UpgradeManifestV1):
         return True
 
     def perform_upgrade(self) -> UpgradeResult:
-        instructions: UpgradeInstruction = self.platform_instructions.get(self.platform, NothingInstruction())
+        instructions: UpgradeInstruction = self.platform_instructions.get(
+            self.platform, NothingInstruction()
+        )
         logger(__name__).debug(self.__dict__)
         logger(__name__).debug(f'Platform: {self.platform}')
         logger(__name__).debug(instructions.__dict__)


### PR DESCRIPTION
#### Summary:
<!-- Provide a concise description of your changes -->
Removes the deprecated `pkg_resources` module in favour of `importlib.metadata`. This also fixes installations by `pipx` etc throwing a "could not determine version" error.

#### Motivation:
<!-- Provide a brief description of why you think these changes need to be made -->
The `pkg_resources` module has been deprecated for many years at this point and formally removed as of 26/2/26. It is thus prudent to replace any uses with the modernised `importlib.metadata`. Additionally, this addresses errors that arise when tools like `pipx` install versions of `setuptools>=82`, which have removed `pkg_resources`, as a dependency of `pros`.

##### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->

#### Test Plan:
<!-- Provide a list of steps that can be taken to verify these changes work as intended -->

- [ ] Complete a fresh install (`brew tap osx-cross/arm && brew install arm-gcc-bin && pipx install pros-cli`) and verify `pros` does not throw an error
